### PR TITLE
Patch V3: New module -- lsm: Use LibStorageMgmt for RAID information.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,7 +265,6 @@ if test "x$enable_iscsi" = "xyes" \
                           [libiscsi can retrieve session information])],
                [have_libiscsi_session_info_msg=", without iscsi sessions"])
 
-
   if test "x$have_iscsi" = "xno"; then
     AC_MSG_ERROR([iSCSI support requested but libraries not found])
   fi
@@ -373,6 +372,36 @@ if test "x$enable_zram" = "xyes" \
     fi
 fi
 
+
+# LSM module
+have_lsm=no
+AC_ARG_ENABLE(
+    lsm, AS_HELP_STRING([--enable-lsm], [enable LibStorageMgmt support]))
+if test "x$enable_lsm" = "xyes" \
+        -o "x$enable_modules" = "xyes" \
+        -o "x$enable_all_modules" = "xyes"; then
+    PKG_CHECK_MODULES(
+        [LIBLSM], [libstoragemgmt >= 1.2.0],
+        [AC_DEFINE(HAVE_LSM, 1, [Define if liblibstoragemgmt is available])
+            have_lsm=yes],
+        [AC_MSG_ERROR([libstoragemgmt 1.2.0 or newer not found.])
+            have_lsm=no])
+
+    PKG_CHECK_MODULES(
+        [LIBCONFIG], [libconfig >= 1.3.2],
+        [AC_DEFINE(HAVE_LSM, 1, [Define if libconfig is available])
+            have_lsm=yes],
+        [AC_MSG_ERROR([libconfig 1.3.2 or newer not found.])
+            have_lsm=no])
+
+  if test "x$have_lsm" = "xno"; then
+    AC_MSG_ERROR([LibStorageMgmt support requested but libraries not found])
+  fi
+fi
+AM_CONDITIONAL(HAVE_LSM, [test "x$have_lsm" = "xyes"])
+
+
+
 AM_CONDITIONAL(HAVE_ZRAM, [test "$have_kbd" = "yes" -a "$have_swap" = "yes"])
 # Internationalization
 #
@@ -405,6 +434,8 @@ modules/lvm2/Makefile
 modules/lvm2/data/Makefile
 modules/zram/Makefile
 modules/zram/data/Makefile
+modules/lsm/Makefile
+modules/lsm/data/Makefile
 doc/Makefile
 doc/storaged-docs.xml.in
 doc/storaged-sections.txt.in
@@ -416,6 +447,7 @@ doc/man/storaged-project.xml
 doc/man/storaged.xml
 doc/man/storagedctl.xml
 doc/man/umount.storaged.xml
+doc/man/storaged_lsm.conf.5
 doc/storaged-docs.xml.iscsi.dbus
 doc/storaged-docs.xml.iscsi.generated
 doc/storaged-sections.txt.iscsi.sections
@@ -433,6 +465,7 @@ doc/storaged-docs.xml.zram.dbus
 doc/storaged-docs.xml.zram.generated
 doc/storaged-sections.txt.zram.sections
 doc/storaged.types.zram
+doc/storaged-docs.xml.lsm.dbus
 po/Makefile.in
 ])
 
@@ -470,4 +503,5 @@ echo "
         iSCSI module:               ${have_iscsi}${have_libiscsi_session_info_msg}
         LVM2  module:               ${have_lvm2}
         Zram module:                ${have_zram}
+        LibStorageMgmt module:      ${have_lsm}
 "

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -131,6 +131,11 @@ CFILE_GLOB += $(top_srcdir)/modules/iscsi/*.c
 AM_CPPFLAGS += -I$(top_srcdir)/modules/iscsi
 GTKDOC_LIBS += $(top_builddir)/modules/iscsi/libstoraged_iscsi.la
 endif # HAVE_ISCSI
+if HAVE_LSM
+	$(AM_V_at) $(SED) -i -f $(DOC_DIR)/$(DOC_MAIN_SGML_FILE).lsm.sed $(builddir)/$(DOC_MAIN_SGML_FILE)
+else
+	$(AM_V_at) $(SED) -i "/<\!-- LSM_GENERATED_SECTIONS -->/d" $(builddir)/$(STORAGED_SECTIONS)
+endif # HAVE_LSM
 
 # GTKDOC for BTRFS
 if HAVE_BTRFS
@@ -149,6 +154,15 @@ CFILE_GLOB += $(top_srcdir)/modules/zram/*.c
 AM_CPPFLAGS += -I$(top_srcdir)/modules/zram
 GTKDOC_LIBS += $(top_builddir)/modules/zram/libstoraged_zram.la
 endif # HAVE_ZRAM
+
+# GTKDOC for LSM
+if HAVE_LSM
+DOC_SOURCE_DIR += $(top_srcdir)/modules/lsm
+HFILE_GLOB += $(top_srcdir)/modules/lsm/*.h
+CFILE_GLOB += $(top_srcdir)/modules/lsm/*.c
+AM_CPPFLAGS += -I$(top_srcdir)/modules/lsm
+GTKDOC_LIBS += $(top_builddir)/modules/lsm/libstoraged_lsm.la
+endif # HAVE_LSM
 
 # ------------------------------------------------------------------------------
 
@@ -189,6 +203,8 @@ EXTRA_DIST +=                                                                  \
 	$(STORAGED_SECTIONS).lvm2.sed                                          \
 	$(STORAGED_SECTIONS).zram.sections.in                                  \
 	$(STORAGED_SECTIONS).zram.sed                                          \
+	$(STORAGED_SECTIONS).lsm.sections.in                                   \
+	$(STORAGED_SECTIONS).lsm.sed                                           \
 	version.xml.in                                                         \
 	TODO-ISCSI
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -33,6 +33,10 @@ storaged-lvm.8 : storaged-lvm.xml
 	$(XSLTPROC) -path "$(builddir)/.." -nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
 endif # HAVE_LVM2
 
+if HAVE_LSM
+notrans_dist_man5_MANS=storaged_lsm.conf.5
+endif
+
 EXTRA_DIST =                                                                   \
 	storagedctl.xml                                                        \
 	storaged.xml                                                           \

--- a/doc/man/storaged_lsm.conf.5.in
+++ b/doc/man/storaged_lsm.conf.5.in
@@ -1,0 +1,94 @@
+.TH storaged_lsm.conf "5" "August 2015" "storaged_lsm.conf @VERSION@" "Storaged lsm module config"
+.SH NAME
+storaged_lsm.conf - Storaged \fBlsm\fR module configuration file.
+
+.SH DESCRIPTION
+The lsm module of storaged uses \fILibStorageMgmt\fR[1] API to provides
+\fBorg.storaged.Storaged.Drive.LSM\fR interface with RAID information for
+external(DAS or SAN) Linux disk drive. Please refer to storage interface
+document for detail.
+
+Some storage system requires extra configuration in
+\fB/etc/storaged/modules.conf.d/storaged_lsm.conf\fR.
+
+.SH storaged_lsm.conf OPTIONS
+.TP
+\fBrefresh_interval = <integer>\fR
+
+The option controls how many seconds should this module refresh
+the RAID information cache. If not defined, the default value is 30(seconds).
+
+.TP
+\fBenable_sim = true|false\fR
+
+This option indicates whether lsm module should try simulator of
+LibStorageMgmt. This is only for developer. If not defined, the default
+value is false(do not enable simulator of LibStorageMgmt).
+If enabled, the \fBsim://\fR URI will be used to query LibStorageMgmt
+simulator plugin.
+
+.TP
+\fBenable_hpsa = true|false\fR
+
+This option indicates whether lsm module should check HP SmartArray.
+If not defined, the default value is true(check HP SmartArray).
+
+To be functional, also requires \fBlibstoragemgmt-hpsa-plugin\fR package be
+installed and well configured. Please refer to the \fIhpsa_lsmplugin(1)\fR
+manpage for detail.
+
+If enabled, the \fBhpsa://\fR URI will be used to query LibStorageMgmt
+HP SmartArray plugin.
+
+.TP
+\fBextra_uris= ["uri_string_1", "uri_string_2"]\fR
+
+This option defines extra LibStorageMgmt URI list here.
+Please refer to \fILibStorageMgmt User Guide\fR[3] for URI format.
+
+Require double quoted string and separated by comma, example:
+
+    extra_uris = ["ontap+ssl://root@ontap.a.ip", "ontap+ssl://root@ontap.b.ip"]
+
+If not defined, empty list(no extra URI loaded) will be used.
+
+.TP
+\fBextra_passwords = ["password_string_1", "password_string_2"]\fR
+
+This options defines the passwords of above URI list.
+Please use double quoted string and separated by comma, example:
+    extra_paasswords = ["password1", "password2"]
+
+.SH Hardware Support Status
+Any hardwares which are supported in LibStorageMgmt with these capabilities
+will get fully support by storaged lsm module:
+
+ * \fBVOLUMES capabilityes\fR with valid VPD83 information.
+
+ * \fBVOLUME_RAID_INFO\fR capabilityes.
+
+Please refer to LibStorageMgmt document website[2] for support status.
+
+Tested hardwares are:
+.TP
+\fBHP SmartArray\fR
+Using \fBlibstoragemgmt-hpsa-plugin\fR package.
+
+.TP
+\fBNetApp ONTAP\fR
+Using \fBlibstoragemgmt-netapp-plugin\fR package.
+
+.SH SEE ALSO
+\fIlsmd (1)\fR, \fIstoraged (8)\fR,
+[1]: https://github.com/libstorage/libstoragemgmt/ ,
+[2]: http://libstorage.github.io/libstoragemgmt-doc/ ,
+[3]: http://libstorage.github.io/libstoragemgmt-doc/doc/user_guide.html ,
+\fIhpsa_lsmplugin(1)\fR,
+\fIontap_lsmplugin(1)\fR
+
+.SH BUGS
+Please report bugs to storaged github pages:
+    https://github.com/storaged-project/storaged/issues
+
+.SH AUTHOR
+Gris Ge <fge@redhat.com>

--- a/doc/storaged-docs.xml.in.in
+++ b/doc/storaged-docs.xml.in.in
@@ -376,6 +376,7 @@
       <!-- ISCSI_DBUS_INTERFACE -->
       <!-- BTRFS_DBUS_INTERFACE -->
       <!-- ZRAM_DBUS_INTERFACE -->
+      <!-- LSM_DBUS_INTERFACE -->
     </chapter>
   </part>
 

--- a/doc/storaged-docs.xml.lsm.dbus.in
+++ b/doc/storaged-docs.xml.lsm.dbus.in
@@ -1,0 +1,1 @@
+      <xi:include href="../modules/lsm/doc_generated-org.storaged.Storaged.Drive.LSM.xml"/>

--- a/doc/storaged-docs.xml.lsm.sed
+++ b/doc/storaged-docs.xml.lsm.sed
@@ -1,0 +1,3 @@
+/<!-- LSM_DBUS_INTERFACE -->/ {
+    r storaged-docs.xml.lsm.dbus
+    d }

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -22,4 +22,8 @@ if HAVE_ZRAM
 SUBDIRS += zram
 endif # HAVE_ZRAM
 
+if HAVE_LSM
+SUBDIRS += lsm
+endif # HAVE_LSM
+
 NULL =

--- a/modules/lsm/Makefile.am
+++ b/modules/lsm/Makefile.am
@@ -1,0 +1,117 @@
+## Process this file with automake to produce Makefile.in
+
+SUBDIRS = data
+
+MODULE_SO = libstoraged_lsm.so
+
+NULL =
+
+INCLUDES = \
+	-I$(top_builddir) -I$(top_srcdir) \
+	-DPACKAGE_LIBEXEC_DIR=\""$(libexecdir)"\" \
+	-DPACKAGE_SYSCONF_DIR=\""$(sysconfdir)"\" \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
+	-DPACKAGE_BIN_DIR=\""$(bindir)"\" \
+	-DPACKAGE_LOCALSTATE_DIR=\""$(localstatedir)"\" \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
+	-DPACKAGE_LIB_DIR=\""$(libdir)"\" \
+	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT \
+	-DSTORAGED_COMPILATION \
+	$(POLKIT_GOBJECT_1_CFLAGS) \
+	$(GLIB_CFLAGS) \
+	$(GIO_CFLAGS) \
+	$(GUDEV_CFLAGS) \
+	$(WARN_CFLAGS) \
+	$(NULL)
+
+$(dbus_built_sources): data/org.storaged.Storaged.lsm.xml Makefile.am
+	gdbus-codegen \
+		--interface-prefix org.storaged.Storaged. \
+		--c-namespace Storaged \
+		--generate-c-code lsm_generated \
+		--generate-docbook doc_generated \
+		$<
+	$(NULL)
+
+
+module_flags = \
+	-export_dynamic \
+	-avoid-version \
+	-module \
+	-no-undefined \
+	-export-symbols-regex \
+	'^storaged_module_.*|g_io_module_load|g_io_module_unload|g_io_module_query'
+
+dbus_built_sources = \
+	lsm_generated.h    lsm_generated.c \
+	$(NULL)
+
+BUILT_SOURCES = \
+	$(dbus_built_sources) \
+	$(NULL)
+
+libstoraged_lsmdir=$(libdir)/storaged/modules
+libstoraged_lsm_LTLIBRARIES=libstoraged_lsm.la
+
+libstoraged_lsmincludedir=$(includedir)/storaged/storaged
+
+libstoraged_lsminclude_HEADERS= \
+	$(top_srcdir)/modules/storagedmoduleiface.h \
+	$(top_srcdir)/modules/storagedmoduleifacetypes.h \
+	$(top_srcdir)/modules/storagedmoduleobject.h \
+	$(NULL)
+
+libstoraged_lsm_la_SOURCES = \
+	$(BUILT_SOURCES) \
+	$(top_srcdir)/modules/storagedmoduleiface.h \
+	$(top_srcdir)/modules/storagedmoduleifacetypes.h \
+	$(top_srcdir)/modules/storagedmoduleobject.h \
+	$(top_srcdir)/modules/storagedmoduleobject.c \
+	lsm_types.h \
+	lsm_module_iface.c \
+	lsm_data.h lsm_data.c \
+	lsm_linux_drive.c \
+	lsm_linux_manager.c \
+	$(NULL)
+
+libstoraged_lsm_la_CPPFLAGS = \
+	-DG_LOG_DOMAIN=\"libstoraged-lsm\" \
+	$(NULL)
+
+libstoraged_lsm_la_CFLAGS = \
+	$(GLIB_CFLAGS) \
+	$(GIO_CFLAGS) \
+	$(GUDEV_CFLAGS) \
+	$(POLKIT_GOBJECT_1_CFLAGS) \
+	$(LIBLSM_CFLAGS) \
+	$(LIBCONFIG_CFLAGS) \
+	$(NULL)
+
+libstoraged_lsm_la_LDFLAGS = $(module_flags)
+
+libstoraged_lsm_la_LIBADD = \
+	$(GLIB_LIBS) \
+	$(GIO_LIBS) \
+	$(GUDEV_LIBS) \
+	$(POLKIT_GOBJECT_1_LIBS) \
+	$(LIBLSM_LIBS) \
+	$(LIBCONFIG_LIBS) \
+	$(NULL)
+
+# ------------------------------------------------------------------------------
+
+CLEANFILES = lsm_generated.[ch]
+
+EXTRA_DIST = \
+	$(NULL)
+
+include ../Makefile.uninstalled
+
+all-local: module_link
+
+dist-hook:
+	(for i in $(BUILT_SOURCES); do rm -f $(distdir)/$$i; done)
+
+clean-local: module_unlink
+	rm -f *~ \
+		$(BUILT_SOURCES)

--- a/modules/lsm/README_DEV_lsm.txt
+++ b/modules/lsm/README_DEV_lsm.txt
@@ -1,0 +1,274 @@
+## How to setup a develop environment for lsm module using ONTAP simulator.
+ * You can use a HP SmartArray server as an develop environment which is
+   much easier to setup, but it's not that flexible like ONTAP simulator
+   for testing LUN create/remove and etc. Check manpage hpsa_lsmplugin(1)
+   from libstoragemgmt-hpsa-plugin if you intend to set HP SmartArray for
+   libstoragemgmt.
+ * Setup an NetApp ONTAP simulator.
+ * Enable http administor way ONTAP:
+      options httpd.enable on
+      options httpd.admin.enable on
+      options httpd.admin.ssl.enable on
+ * Assuming ONTAP simulator has dns name as 'na-sim'. Admin account is 'root'.
+ * Follow some guide to create a LUN and map to a iscsi initiator, or these
+   commands:
+        aggr create test_ag -t raid_dp 6       # 6 disk RAID 6.
+        vol create /vol/test_ag test_ag 1G
+        iscsi start
+        igroup create -i -t linux gris-test iqn.1994-05.com.redhat:gris-st-lsm-test
+        lun create -t linux -s 4m /vol/test_vg/lun1
+        lun map /vol/test_vg/lun1 gris-test
+ * On your developer host or VM. Setup the iscsi initiator.
+        sudo yum install iscsi-initiator-utils -y
+        echo 'InitiatorName=iqn.1994-05.com.redhat:gris-st-lsm-test' | \
+            sudo tee /etc/iscsi/initiatorname.iscsi
+        iscsiadm -m discovery -t st -p na-sim
+        iscsiadm -m node -l
+ * Install libstoragemgmt-devel 1.2+ and libstoragemgmt-netapp-plugin.
+ * Try these command to test whether libstoragemgmt works:
+    systemctl start libstoragemgmt
+    lsmcli ls -l -u ontap://root@na-sim -P      # Input ONTAP password.
+ * It should print some information about this ONTAP array.
+ * Compile and install storaged with lsm module:
+    ./autogen.sh  --libdir=/usr/lib64 --prefix=/usr  --sysconfdir /etc \
+        --enable-lsm --disable-lvm2 --disable-dummy --disable-iscsi
+    make -j5
+    sudo make install
+ * Update /etc/storaged/modules.conf.d/storaged_lsm.conf to hold these lines:
+    extra_uris = ["ontap://root@na-sim"]
+    extra_passwords = ["your_ontap_password"]
+ * Run storaged with lsm module loading:
+    sudo valgrind --show-leak-kinds=all --leak-check=full \
+        --trace-children=yes --show-reachable=no
+        --log-file=/tmp/mem_check.log  /usr/libexec/storaged/storaged
+        --force-load-modules
+ * Use qdbus(or other tool) to query dbus interface:
+    sudo qdbus --system org.storaged.Storaged
+ * Use "dbus-monitor --system" command to monitor dbus signals.
+
+## Files
+* lsm_module_iface.c
+
+    Implemented the public module public method defined by
+    modules/storagedmoduleifacetypes.h
+
+* lsm_data.c lsm_data.h
+
+    Use LibStorageMgmt API to query RAID info. Lock is used to protect
+    static data.
+
+* lsm_linux_drive.c
+
+    Handling interface data fill in and update then using glib main loop
+    event.
+
+* lsm_linux_manager.c
+
+    Empty interface for org.storaged.Storaged.Manager.LSM.
+
+* lsm_types.h
+
+    Methods used by lsm_module_iface.c but implemented in
+    lsm_linux_drive.c and lsm_linux_manager.c.
+
+## Workflow
+
+* storaged_module_manager_load_modules () of
+  src/storagedmodulemanager.c
+
+    Check whether libstoraged_lsm.so has required g_module_symbol () in
+    storaged_module_manager_load_modules ().
+
+* storaged_linux_provider_start () of src/storagedlinuxprovider.c
+
+    If module is loaded __after__ storaged daemon, only 1 codeplugin
+    will be kicked off by ensure_modules ();
+
+    If module is enabled via command option --force-load-modules
+    __3__ times coldplug (generate add udev event on all devices) will be
+    performed:
+
+      * ensure_modules () invoke codeplug.
+      * storaged_linux_provider_start () do twice codeplugs.
+
+    The codeplug just generate add udev event on all devices which
+    will then handled by storaged_linux_drive_object_uevent ()
+    of src/storagedlinuxdriveobject.c in our case.
+
+* The add udev event of disk drive was handled by
+  storaged_linux_drive_object_uevent () of src/storagedlinuxdriveobject.c.
+
+* Then update_iface () of src/storagedlinuxdriveobject.c invoke module
+  functions:
+    * _drive_check () of lsm_module_iface.c:
+        If retrun TRUE, the dbus org.storaged.Storaged.Drive.LSM interface
+        will be created.
+        In order to refresh the lsm cache when new disk attached,
+        in this method, we do extra refresh if not found in cache.
+        Do extra check like about skipping CD ROM, skipping first empty
+        codeplug, and validating vpd83.
+    * _drive_connect () of lsm_module_iface.c:
+        No idea what this for. We just return void.
+    * _drive_update () of lsm_module_iface.c:
+        For add udev event, invoke storaged_linux_drive_lsm_update () of
+        lsm_linux_drive.c which create loop event to refresh cache at
+        certain interval (configureable).
+        For remove udev event, just g_object_unref ().
+    * _on_refresh_data () of lsm_linux_drive.c:
+        Triggered by glib loop event, refresh raid info via
+        std_lsm_vol_data_get () of lsm_data.c.
+
+## LSM Connection internal data layout -- lsm_data.c
+
+This module methods will not run in multiple threads, we don't have
+mutex lock to protect static data.
+
+Data layout:
+
+
+_conf_lsm_uri_sets =  [struct _LsmConnData * ];
+
+    create:     _load_module_conf ()
+                        |
+                        v
+                    _lsm_uri_set_new ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_ptr_array_unref ()
+                        |
+                        v
+                    _free_lsm_uri_set ()
+    used by:    _create_lsm_connect ()
+    notes:      Might allow user to define timeout and etc in the future.
+
+_all_lsm_conn_array = [lsm_connect *];
+
+    create:     std_lsm_data_init ()
+                        |
+                        v
+                    _create_lsm_connect ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_ptr_array_unref ()
+                        |
+                        v
+                    _free_lsm_connect ()
+    used by:    std_lsm_vpd83_list_refresh ()
+    notes:      As we are save lsm_connect pointer in many spaces,
+                we need this array for clean up and VPD83 cache refresh.
+
+_supported_sys_id_hash = {
+    const char *sys_id => static const gboolean _sys_id_supported;
+}
+
+    create:     std_lsm_data_init ()
+                        |
+                        v
+                    _fill_supported_system_id_hash ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_hash_table_unref ()
+                        |
+                        v
+                    g_free ()
+    used by:    _get_supported_lsm_volumes ()
+                _get_supported_lsm_pls ()
+    notes:      Save the supported system.id to filter out unsupported
+                volumes and pools.
+
+_vpd83_2_lsm_conn_data_hash = {
+    const char *vpd83 => struct _LsmConnData *;
+};
+
+    create:     std_lsm_data_init ()
+                        |
+                        v
+                    _fill_vpd83_2_lsm_conn_data_hash ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_hash_table_unref ()
+                        |
+                        v
+                    _free_lsm_conn_data ()
+    used by:    _lsm_pl_data_lookup ()
+                _lsm_vri_data_lookup ()
+                _refresh_lsm_vri_data ()
+    notes:      Cache the required data for lsm_volume_raid_info (),
+                lsm_pools () and methods.
+
+_pl_id_2_lsm_pl_data_hash = {
+    const char *pl_id => struct _LsmPlData *;
+}
+
+    create:     std_lsm_data_init ()
+                        |
+                        v
+                    _fill_pl_id_2_lsm_pl_data_hash ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_hash_table_unref ()
+                        |
+                        v
+                    _free_lsm_pl_data ()
+    used by:    _lsm_pl_data_lookup ()
+    notes:      Cache the pool status to avoid duplicate wasted call.
+
+_vpd83_2_lsm_vri_data_hash = {
+    const char *vpd83 => struct _LsmVriData *;
+}
+
+    create:     _lsm_vri_data_lookup ()
+                        |
+                        v
+                    _refresh_lsm_vri_data ()
+    free:       std_lsm_data_teardown ()
+                        |
+                        v
+                    g_hash_table_unref ()
+                        |
+                        v
+                    _free_lsm_vri_data ()
+    used by:    _lsm_pl_data_lookup ()
+    notes:      Cache the lsm_volume_raid_info () returned data.
+
+
+* std_lsm_data_init ():
+    * Read configuration -- _read_module_conf ().
+    * Create LSM connection for each URI. -- _create_lsm_connect ().
+        * Invoke lsm_system_list () and lsm_capabilities() to check
+          LSM_CAP_VOLUMES and LSM_CAP_VOLUME_RAID_INFO capabilities.
+
+            _get_supported_lsm_systems ()
+
+        * Invoke lsm_volumes_list () and lsm_pool_list().
+
+            _get_supported_lsm_volumes ()
+            _get_supported_lsm_pools ()
+
+        * Create these static hash tables:
+            * _lsm_conn_data_array
+            * _vpd83_2_lsm_conn_data_hash
+            * _pl_id_2_lsm_pl_data_hash
+            * _vpd83_2_lsm_vri_data_hash
+              # ^ this will be fill in when requested via
+              # std_lsm_vol_data_get ().
+
+* std_lsm_vol_data_get ():
+    Combine data retrived from _lsm_pl_data_lookup () and
+    _lsm_vri_data_lookup () to generate struct StdLsmVolData *.
+
+* std_lsm_data_teardown ():
+    * Free memorys and close connections.
+
+## TODO
+* Warnning:
+    (storaged:12885): GLib-GObject-WARNING **: g_object_notify: object class
+    'StoragedLinuxDriveObject' has no property named 'drive-lsm'
+
+* Add extra sections to the documentation, currently we only have dbus
+  interface documentation.

--- a/modules/lsm/TEST_NOTE_lsm.txt
+++ b/modules/lsm/TEST_NOTE_lsm.txt
@@ -1,0 +1,21 @@
+## NetApp ONTAP iSCSI Test
+
+ * New LUN attached after storaged(with module loaded) started.
+   `iscsiadm -m session -R`
+
+ * Exiting LUN removed from storage array. LSM dbus interface should be purged.
+    * iSCSI
+        * Got change uevent(size to 0) on next I/O, but /dev/sdX and sysfs
+          entries still exist.
+
+ * Delete certain disk via sysfs and scan it back:
+    echo 1 | sudo tee /sys/block/sdX/device/delete
+        # This is the a simulation of FC/FCoE dev_lose_tmo.
+    find /sys/class/scsi_host/*/scan -exec echo {} \;  \
+        -exec sudo bash -c "echo '- - -' > {}" \;
+
+ * Degrade the RAID to check dbus signal.
+    netapp shell:
+        disk simpull v5.32
+    linux dbus monitor:
+        dbus-monitor --system

--- a/modules/lsm/data/Makefile.am
+++ b/modules/lsm/data/Makefile.am
@@ -1,0 +1,12 @@
+
+NULL =
+
+@INTLTOOL_POLICY_RULE@
+
+modulesconfdir = $(sysconfdir)/storaged/modules.conf.d
+modulesconf_DATA = storaged_lsm.conf
+
+EXTRA_DIST = \
+	org.storaged.Storaged.lsm.xml \
+	storaged_lsm.conf \
+	$(NULL)

--- a/modules/lsm/data/org.storaged.Storaged.lsm.xml
+++ b/modules/lsm/data/org.storaged.Storaged.lsm.xml
@@ -1,0 +1,122 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+
+<!--
+ Copyright (C) 2014 Tomas Bzatek <tbzatek@redhat.com>
+               2015 Gris Ge <fge@redhat.com>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307, USA.
+-->
+
+  <!-- ******************************************************************* -->
+
+  <!--
+    org.storaged.Storaged.Drive.LSM:
+    @short_description: LSM interface exported on disk objects
+
+    Objects implementing this interface also implement the
+    #org.storaged.Storaged.Drive interface.
+  -->
+  <interface name="org.storaged.Storaged.Drive.LSM">
+    <!-- IsOK:
+        Whether this drive is read and writeable without any error or warnings.
+        It's the single preliminary check on whether things go wrong.
+        Noted: even from user's view, RAID degrade does not cause any
+        error or warning at OS level, the 'isOK' property will still be set
+        as 'FALSE' to suggest user to do more checking on what's going on.
+    -->
+    <property name="IsOK" type="b" access="read"/>
+
+    <!-- IsRaidDegraded:
+        Whether this drive is degraded RAID, for example, one disk failure
+        in RAID 5 group is considered as degraded RAID.
+    -->
+    <property name="IsRaidDegraded" type="b" access="read"/>
+
+    <!-- IsRaidError:
+        Whether this drive is facing RAID error, for example, two disks
+        failure in RAID 5 group at the same time is considered as RAID error,
+        user will lose data access and facing write failure.
+    -->
+    <property name="IsRaidError" type="b" access="read"/>
+
+    <!-- IsRaidVerifying:
+        Whether the RAID group of current drive allocated from is
+        verifying its data integrity by comparing mirror(RAID1) or verifying
+        parity(RAID 5/6).
+    -->
+    <property name="IsRaidVerifying" type="b" access="read"/>
+
+    <!-- IsRaidReconstructing:
+        Whether the RAID group of current drive allocated from is
+        reconstructing its data on newly joined disk or out-synced disk.
+    -->
+    <property name="IsRaidReconstructing" type="b" access="read"/>
+
+    <!-- RaidType:
+         A string of backend RAID type of this disk drive.
+         Could be one of these values:
+            JBOD, RAID 0, RAID 1, RAID 5, RAID 6, RAID 10, RAID 50, RAID 60
+        There will be a space between RAID number and 'RAID' string.
+        If unknown, leave it as empty.
+    -->
+    <property name="RaidType" type="s" access="read"/>
+
+    <!-- StatusInfo:
+         A message for administrator about RAID detail issue.
+         Some examples:
+            Disk enclosure 1 slot 9(serial: CVDA452606ME1207GN) is offline.
+            Disk enclosure 1 slot 10 is predicted to be fail soon.
+        Empty string if no issue or LibStorageMgmt failed to retrieve so.
+    -->
+    <property name="StatusInfo" type="s" access="read"/>
+
+
+    <!-- MinIoSize:
+        The minimum I/O size, device preferred I/O size for random I/O.
+        Any I/O size not equal to a multiple of this value may get
+        significant speed penalty. Normally it refers to strip size of
+        each RAID disk(extent). If LibStorageMgmt failed to detect min_io_size,
+        it will try these values in the sequence of:
+            logical sector size -> physical sector size ->  0
+    -->
+    <property name="MinIoSize" type="u" access="read"/>
+
+    <!-- OptIoSize:
+        The optimal I/O size, device preferred I/O size for sequential
+        I/O. Normally it refers to RAID group stripe size. If LibStorageMgmt
+        failed to detect opt_io_size, it will be set to 0.
+    -->
+    <property name="OptIoSize" type="u" access="read"/>
+
+    <!-- RaidDiskCount:
+        The count of disk assebled the RAID group where this disk drive came
+        from. This impact the performance of this disk drive.
+        If LibStorageMgmt failed to detect RAID disk count, it will be set to
+        0.
+    -->
+    <property name="RaidDiskCount" type="u" access="read"/>
+
+  </interface>
+  <!--
+    org.storaged.Storaged.Manager.LSM:
+    @short_description: LSM add-on to the manager singleton
+  -->
+  <interface name="org.storaged.Storaged.Manager.LSM">
+  </interface>
+</node>

--- a/modules/lsm/data/storaged_lsm.conf
+++ b/modules/lsm/data/storaged_lsm.conf
@@ -1,0 +1,19 @@
+refresh_interval = 30
+## Interval in seconds between every LibStorageMgmt
+## data refresh. It define how long will the monitor
+## thread noticed state change before it happened.
+## Only unsigned integer is supported.
+## If not define, then 30.
+
+enable_sim = false
+## Only for developer, Valid value is true or false.
+## If not define, then false.
+
+enable_hpsa = true
+## Load LibStorageMgmt HP Smart Array plugin. Valid value is true or false.
+## If not define, then true.
+
+#extra_uris = ["ontap+ssl://root@na-sim"]
+#extra_passwords = ["password"]
+## Extra URI and password to load. Should be quoted and be splited by ','
+## By default, no extra URI will be loaded.

--- a/modules/lsm/lsm_data.c
+++ b/modules/lsm/lsm_data.c
@@ -1,0 +1,1110 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ *
+ */
+
+#include "lsm_data.h"
+
+#include <src/storagedlogging.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+#include <libconfig.h>
+#include <string.h>
+#include <stdint.h>
+
+#define _STD_LSM_SIM_URI "sim://"
+#define _STD_LSM_HPSA_URI "hpsa://"
+
+#define _STD_LSM_CONF_PATH "/etc/storaged/modules.conf.d/storaged_lsm.conf"
+#define _STD_LSM_CONF_REFRESH_KEYNAME "refresh_interval"
+#define _STD_LSM_CONF_SIM_KEYNAME "enable_sim"
+#define _STD_LSM_CONF_HPSA_KEYNAME "enable_hpsa"
+#define _STD_LSM_CONF_EXT_URIS_KEYNAME "extra_uris"
+#define _STD_LSM_CONF_EXT_PASS_KEYNAME "extra_passwords"
+#define _STD_LSM_CONNECTION_DEFAULT_TMO 30000
+
+/*
+ * _LsmUriSet is holding the URI and password string pointers.
+ */
+struct _LsmUriSet
+{
+  const char *uri;
+  const char *password;
+};
+
+/*
+ * _LsmConnData is holding lsm connection information for each
+ * volume.
+ */
+struct _LsmConnData
+{
+  lsm_connect *lsm_conn;
+  lsm_volume *lsm_vol;
+  const char *pl_id;
+};
+
+/*
+ * _LsmPlData is holding the pool information.
+ * It's shared by all the volumes under the same pool.
+ */
+struct _LsmPlData
+{
+  gint64 last_refresh_time;
+  gboolean is_ok;
+  gboolean is_raid_degraded;
+  gboolean is_raid_error;
+  gboolean is_raid_verifying;
+  gboolean is_raid_reconstructing;
+  const char *status_info;
+};
+
+/*
+ * _LsmVriData is holding the volume RAID information.
+ */
+struct _LsmVriData
+{
+  gint64 last_refresh_time;
+  const char *raid_type_str;
+  uint32_t min_io_size;
+  uint32_t opt_io_size;
+  uint32_t raid_disk_count;
+};
+
+static GPtrArray *_conf_lsm_uri_sets = NULL;
+static uint32_t _conf_refresh_interval = 30;
+static const gboolean _sys_id_supported = TRUE;
+static GPtrArray *_all_lsm_conn_array = NULL;
+static GHashTable *_supported_sys_id_hash = NULL;
+static GHashTable *_vpd83_2_lsm_conn_data_hash = NULL;
+static GHashTable *_pl_id_2_lsm_pl_data_hash = NULL;
+static GHashTable *_vpd83_2_lsm_vri_data_hash = NULL;
+
+static struct _LsmUriSet *_lsm_uri_set_new (const char *uri, const char *pass);
+static void _handle_lsm_error (const char *msg, lsm_connect *lsm_conn);
+static const char *_lsm_raid_type_to_str (lsm_volume_raid_type raid_type);
+static void _load_module_conf (void);
+static lsm_connect *_create_lsm_connect (struct _LsmUriSet *lsm_uri_set);
+static GPtrArray *_get_supported_lsm_volumes (lsm_connect *lsm_conn);
+static GPtrArray *_get_supported_lsm_pls (lsm_connect *lsm_conn);
+static gboolean _fill_supported_system_id_hash (lsm_connect *lsm_conn);
+static void _fill_pl_id_2_lsm_pl_data_hash (GPtrArray *lsm_pl_array,
+                                            gint64 last_refresh_time);
+static void _fill_vpd83_2_lsm_conn_data_hash (lsm_connect *lsm_conn,
+                                              GPtrArray *lsm_vol_array);
+static void _fill_lsm_pl_data (struct _LsmPlData *lsm_pl_data,
+                               lsm_pool *lsm_pl, gint64 last_refresh_time);
+static struct _LsmVriData *
+_refresh_lsm_vri_data (struct _LsmConnData *lsm_conn_data, const char *vpd83);
+static struct _LsmPlData *_lsm_pl_data_lookup (const char *vpd83);
+static struct _LsmVriData *_lsm_vri_data_lookup (const char *vpd83);
+
+static void _free_lsm_connect (gpointer data);
+static void _free_lsm_uri_set (gpointer data);
+static void _free_lsm_conn_data (gpointer data);
+static void _free_lsm_pl_data (gpointer data);
+static void _free_lsm_vri_data (gpointer data);
+
+static struct _LsmUriSet *
+_lsm_uri_set_new (const char *uri, const char *pass)
+{
+  struct _LsmUriSet *lsm_uri_set;
+
+  lsm_uri_set = (struct _LsmUriSet *) g_malloc (sizeof (struct _LsmUriSet));
+  lsm_uri_set->uri = g_strdup (uri);
+  lsm_uri_set->password = g_strdup (pass);
+  return lsm_uri_set;
+}
+
+/*
+ * Print lsm error via storaged_warning ()
+ *
+ */
+static void
+_handle_lsm_error (const char *msg, lsm_connect *lsm_conn)
+{
+  lsm_error *lsm_err = NULL;
+
+  lsm_err = lsm_error_last_get (lsm_conn);
+  if (lsm_err)
+    {
+      storaged_warning ("%s. Error code: %d, error message: %s",
+                        msg, lsm_error_number_get (lsm_err),
+                        lsm_error_message_get (lsm_err));
+      lsm_error_free (lsm_err);
+    }
+  else
+    {
+      storaged_warning
+        ("LSM: %s. But failed to retrieve error code and message", msg);
+    }
+  return;
+}
+
+/*
+ * Convert lsm_volume_raid_type to 'RAID 1' like string.
+ * The memory of string does not require manually free.
+ */
+
+static const char *
+_lsm_raid_type_to_str (lsm_volume_raid_type raid_type)
+{
+  switch (raid_type)
+    {
+    case LSM_VOLUME_RAID_TYPE_JBOD:
+      return "JBOD";
+    case LSM_VOLUME_RAID_TYPE_RAID0:
+      return "RAID 0";
+    case LSM_VOLUME_RAID_TYPE_RAID1:
+      return "RAID 1";
+    case LSM_VOLUME_RAID_TYPE_RAID5:
+      return "RAID 5";
+    case LSM_VOLUME_RAID_TYPE_RAID6:
+      return "RAID 6";
+    case LSM_VOLUME_RAID_TYPE_RAID10:
+      return "RAID 10";
+    case LSM_VOLUME_RAID_TYPE_RAID50:
+      return "RAID 50";
+    case LSM_VOLUME_RAID_TYPE_RAID60:
+      return "RAID 60";
+    default:
+      return "";
+    }
+}
+
+/*
+ * Use libconfig.h to read config file _STD_LSM_CONF_PATH.
+ * Set these static variables
+ *    GPtrArray _conf_lsm_uri_sets
+ *    gint64 _conf_refresh_interval
+ * Memory should be freed by
+ */
+static void
+_load_module_conf (void)
+{
+  struct _LsmUriSet *lsm_uri_set = NULL;
+  config_t *cfg = NULL;
+  int cfg_value_int = 0;
+  config_setting_t *ext_uris = NULL;
+  config_setting_t *ext_pass = NULL;
+  const char *uri = NULL;
+  const char *password = NULL;
+  int i;
+
+  storaged_debug ("LSM: loading configure");
+
+  cfg = (config_t *) g_malloc (sizeof (config_t));
+  config_init (cfg);
+  if (CONFIG_TRUE != config_read_file (cfg, _STD_LSM_CONF_PATH))
+    {
+      storaged_warning
+        ("LSM: Failed to load config: %s, error: %s at line %d",
+         _STD_LSM_CONF_PATH, config_error_text (cfg), config_error_line (cfg));
+      _conf_lsm_uri_sets = NULL;
+      goto out;
+    }
+
+  config_lookup_int (cfg, _STD_LSM_CONF_REFRESH_KEYNAME, &cfg_value_int);
+  if (cfg_value_int > 0)
+    {
+      _conf_refresh_interval = cfg_value_int & UINT32_MAX;
+    }
+
+  _conf_lsm_uri_sets =
+    g_ptr_array_new_full (0, (GDestroyNotify) _free_lsm_uri_set );
+
+  cfg_value_int = 0;            // Disable simualtor by default
+  config_lookup_bool (cfg, _STD_LSM_CONF_SIM_KEYNAME, &cfg_value_int);
+
+  if (cfg_value_int)
+    {
+      lsm_uri_set = _lsm_uri_set_new (_STD_LSM_SIM_URI, NULL);
+      g_ptr_array_add (_conf_lsm_uri_sets, lsm_uri_set);
+    }
+
+  cfg_value_int = 1;            // Enable HPSA by default.
+  config_lookup_bool (cfg, _STD_LSM_CONF_HPSA_KEYNAME, &cfg_value_int);
+  if (cfg_value_int)
+    {
+      lsm_uri_set = _lsm_uri_set_new (_STD_LSM_HPSA_URI, NULL);
+      g_ptr_array_add (_conf_lsm_uri_sets, lsm_uri_set);
+    }
+
+  // Check extra_uris and extra_passwords
+  ext_uris = config_lookup (cfg, _STD_LSM_CONF_EXT_URIS_KEYNAME);
+  if (ext_uris && !config_setting_is_array (ext_uris))
+    {
+      storaged_warning ("LSM: Invalid setting of '%s' in %s",
+                        _STD_LSM_CONF_EXT_URIS_KEYNAME, _STD_LSM_CONF_PATH);
+      goto out;
+    }
+
+  ext_pass = config_lookup (cfg, _STD_LSM_CONF_EXT_PASS_KEYNAME);
+  if (ext_pass && !config_setting_is_array (ext_pass))
+    {
+      storaged_warning ("LSM: Invalid configure setting of '%s' in %s",
+                        _STD_LSM_CONF_EXT_PASS_KEYNAME, _STD_LSM_CONF_PATH);
+      goto out;
+    }
+
+  if (ext_uris == NULL && ext_pass == NULL)
+    {
+      goto out;
+    }
+
+  if ((ext_uris && !ext_pass) || (!ext_uris && ext_pass))
+    {
+      storaged_warning ("LSM: Invalid configure setting: '%s' and '%s' "
+                        "should be used in pair",
+                        _STD_LSM_CONF_EXT_URIS_KEYNAME,
+                        _STD_LSM_CONF_EXT_PASS_KEYNAME);
+      goto out;
+    }
+
+  if (config_setting_length (ext_uris) != config_setting_length (ext_pass))
+    {
+      storaged_warning ("LSM: Invalid configure setting: the element "
+                        "count of '%s' and '%s' does not match.",
+                        _STD_LSM_CONF_EXT_URIS_KEYNAME,
+                        _STD_LSM_CONF_EXT_PASS_KEYNAME);
+      goto out;
+    }
+
+  for (i = 0; i < config_setting_length (ext_uris); ++i)
+    {
+      uri = config_setting_get_string_elem (ext_uris, i);
+      password = config_setting_get_string_elem (ext_pass, i);
+
+      if (strlen (uri) <= 0)
+        continue;
+      storaged_debug ("LSM: Fount extra URI: %s", uri);
+
+      lsm_uri_set = _lsm_uri_set_new (uri, password);
+      g_ptr_array_add (_conf_lsm_uri_sets, lsm_uri_set);
+    }
+
+out:
+  if (_conf_lsm_uri_sets->len == 0) {
+      g_ptr_array_unref (_conf_lsm_uri_sets);
+      _conf_lsm_uri_sets = NULL;
+  }
+  config_destroy (cfg);
+  g_free ((gpointer) cfg);
+}
+
+static lsm_connect *
+_create_lsm_connect (struct _LsmUriSet *lsm_uri_set)
+{
+  lsm_connect *lsm_conn = NULL;
+  lsm_error *lsm_err = NULL;
+  int lsm_rc;
+  const char *uri = NULL;
+  const char *password = NULL;
+
+  if (lsm_uri_set == NULL)
+    {
+      storaged_debug ("LSM: _create_lsm_connect (): Skip on NULL lsm_uri_set");
+      return NULL;
+    }
+  uri = lsm_uri_set->uri;
+  password = lsm_uri_set->password;
+
+  storaged_debug ("LSM: Connecting to URI: %s", uri);
+  lsm_rc = lsm_connect_password (uri, password, &lsm_conn,
+                                 _STD_LSM_CONNECTION_DEFAULT_TMO,
+                                 &lsm_err, LSM_CLIENT_FLAG_RSVD);
+  if (lsm_rc == LSM_ERR_DAEMON_NOT_RUNNING)
+    {
+      storaged_warning ("LSM: The libStorageMgmt daemon is not running "
+                        "(process name lsmd), try "
+                        "'service libstoragemgmt start'");
+      lsm_error_free (lsm_err);
+      return NULL;
+    }
+  if (lsm_rc != LSM_ERR_OK)
+    {
+      storaged_warning ("LSM: Failed to connect plugin via URI '%s', "
+                        "error code: %d, error message: %s",
+                        uri, lsm_error_number_get (lsm_err),
+                        lsm_error_message_get (lsm_err));
+      lsm_error_free (lsm_err);
+      return NULL;
+    }
+  storaged_debug ("LSM: Plugin for URI '%s' connected", uri);
+  return lsm_conn;
+}
+
+/*
+ * Update _supported_sys_id_hash GHashTable when system is having
+ * LSM_CAP_VOLUMES and LSM_CAP_VOLUME_RAID_INFO capabilities:
+ *  {
+ *    system_id: TRUE;
+ *  }
+ * Return TRUE when provided connection has supported system, or FALSE.
+ */
+static gboolean
+_fill_supported_system_id_hash (lsm_connect *lsm_conn)
+{
+  lsm_storage_capabilities *lsm_cap = NULL;
+  lsm_system **lsm_syss = NULL;
+  uint32_t lsm_sys_count = 0;
+  int lsm_rc = 0;
+  uint32_t i = 0;
+  const char *lsm_sys_id = NULL;
+  gboolean rc = FALSE;
+
+  lsm_rc = lsm_system_list (lsm_conn, &lsm_syss, &lsm_sys_count,
+                            LSM_CLIENT_FLAG_RSVD);
+
+  if (lsm_rc != LSM_ERR_OK)
+    {
+      _handle_lsm_error ("LSM: Failed to list systems", lsm_conn);
+      return rc;
+    }
+
+  if (lsm_sys_count == 0)
+    {
+      storaged_debug ("LSM: No system found in this lsm connection");
+      return rc;
+    }
+
+  for (i = 0; i < lsm_sys_count; ++i)
+    {
+      lsm_sys_id = lsm_system_id_get (lsm_syss[i]);
+      if ((lsm_sys_id == NULL) || (strlen (lsm_sys_id) == 0))
+        {
+          storaged_debug ("LSM: BUG: got NULL system ID");
+          continue;
+        }
+      lsm_cap = NULL;
+      lsm_rc = lsm_capabilities (lsm_conn, lsm_syss[i], &lsm_cap,
+                                 LSM_CLIENT_FLAG_RSVD);
+      if (lsm_rc != LSM_ERR_OK)
+        {
+          _handle_lsm_error ("LSM: error on lsm_capabilities () ",
+                             lsm_conn);
+          continue;
+        }
+      if (lsm_capability_supported (lsm_cap, LSM_CAP_VOLUMES) &&
+          lsm_capability_supported (lsm_cap, LSM_CAP_VOLUME_RAID_INFO))
+        {
+          storaged_debug ("LSM: System '%s'(%s) is connected and supported.",
+                          lsm_system_name_get (lsm_syss[i]), lsm_sys_id);
+          g_hash_table_insert (_supported_sys_id_hash,
+                               (gpointer) g_strdup (lsm_sys_id),
+                               (gpointer) &_sys_id_supported);
+          rc = TRUE;
+        }
+      else
+        {
+          storaged_debug ("LSM: System '%s'(%s) is not supporting "
+                          "LSM_CAP_VOLUMES or LSM_CAP_VOLUME_RAID_INFO.",
+                          lsm_system_name_get (lsm_syss[i]), lsm_sys_id);
+        }
+      lsm_capability_record_free (lsm_cap);
+    }
+
+  lsm_system_record_array_free (lsm_syss, lsm_sys_count);
+
+  return rc;
+}
+
+/*
+ * Return an array of lsm_volume which system_id is in supported_sys_id_hash.
+ */
+static GPtrArray *
+_get_supported_lsm_volumes (lsm_connect *lsm_conn)
+{
+  GPtrArray *lsm_vol_array = NULL;
+  lsm_volume **lsm_vols = NULL;
+  lsm_volume *lsm_vol_dup = NULL;
+  const char *lsm_sys_id = NULL;
+  uint32_t lsm_vol_count = 0;
+  int rc = 0;
+  uint32_t i = 0;
+  const char *lsm_vpd83;
+
+  rc = lsm_volume_list (lsm_conn, NULL, NULL, &lsm_vols, &lsm_vol_count,
+                        LSM_CLIENT_FLAG_RSVD);
+  if (rc != LSM_ERR_OK)
+    {
+      _handle_lsm_error ("LSM: Failed to list volumes", lsm_conn);
+      return NULL;
+    }
+
+  lsm_vol_array =
+    g_ptr_array_new_full (0, (GDestroyNotify) lsm_volume_record_free);
+
+  for (i = 0; i < lsm_vol_count; ++i)
+    {
+
+      lsm_vpd83 = lsm_volume_vpd83_get (lsm_vols[i]);
+      if (strlen (lsm_vpd83) == 0)
+        {
+          storaged_debug ("LSM: Volume %s(%s) has no VPD 83.",
+                          lsm_volume_id_get (lsm_vols[i]),
+                          lsm_volume_name_get (lsm_vols[i]));
+          continue;
+        }
+
+      lsm_sys_id = lsm_volume_system_id_get (lsm_vols[i]);
+      if (g_hash_table_lookup (_supported_sys_id_hash, lsm_sys_id) == NULL)
+        {
+          storaged_debug
+            ("LSM: Volume VPD %s been rule out as its system is not "
+             "supported", lsm_vpd83);
+          continue;
+        }
+
+      lsm_vol_dup = lsm_volume_record_copy (lsm_vols[i]);
+      if (lsm_vol_dup == NULL)
+          // No memory, quit as g_malloc () did.
+          exit (1);
+      g_ptr_array_add (lsm_vol_array, lsm_vol_dup);
+    }
+
+  lsm_volume_record_array_free (lsm_vols, lsm_vol_count);
+  if (lsm_vol_array->len == 0)
+    {
+      g_ptr_array_unref (lsm_vol_array);
+      return NULL;
+    }
+  return lsm_vol_array;
+}
+
+/*
+ * Return an array of lsm_pool which system_id is in supported_sys_id_hash.
+ */
+static GPtrArray *
+_get_supported_lsm_pls (lsm_connect *lsm_conn)
+{
+  GPtrArray *lsm_pl_array = NULL;
+  lsm_pool **lsm_pls = NULL;
+  lsm_pool *lsm_pl_dup = NULL;
+  const char *lsm_sys_id = NULL;
+  uint32_t lsm_pl_count = 0;
+  uint32_t i = 0;
+  int lsm_rc;
+
+  lsm_rc = lsm_pool_list (lsm_conn, NULL, NULL, &lsm_pls,
+                          &lsm_pl_count, LSM_CLIENT_FLAG_RSVD);
+
+  if (lsm_rc != LSM_ERR_OK)
+    {
+      _handle_lsm_error ("LSM: Failed to list pools", lsm_conn);
+      return NULL;
+    }
+
+  lsm_pl_array =
+    g_ptr_array_new_full (0, (GDestroyNotify) lsm_pool_record_free);
+
+  for (i = 0; i < lsm_pl_count; ++i)
+    {
+
+      lsm_sys_id = lsm_pool_system_id_get (lsm_pls[i]);
+      if (g_hash_table_lookup (_supported_sys_id_hash, lsm_sys_id) == NULL)
+        {
+          storaged_debug
+            ("LSM: Pool %s(%s) been rule out as its system is not supported",
+             lsm_pool_name_get (lsm_pls[i]),
+             lsm_pool_id_get (lsm_pls[i]));
+          continue;
+        }
+
+      lsm_pl_dup = lsm_pool_record_copy (lsm_pls[i]);
+      if (lsm_pl_dup == NULL)
+        {
+          // No memory, quit as g_malloc () did.
+          exit (1);
+        }
+      g_ptr_array_add (lsm_pl_array, lsm_pl_dup);
+    }
+  lsm_pool_record_array_free (lsm_pls, lsm_pl_count);
+  if (lsm_pl_array->len == 0)
+    {
+      g_ptr_array_unref (lsm_pl_array);
+      return NULL;
+    }
+  return lsm_pl_array;
+}
+
+static void
+_fill_pl_id_2_lsm_pl_data_hash (GPtrArray *lsm_pl_array,
+                                gint64 last_refresh_time)
+{
+  struct _LsmPlData *lsm_pl_data = NULL;
+  lsm_pool *lsm_pl = NULL;
+  const char *pl_id = NULL;
+  const char *orig_pl_id = NULL;
+  struct _LsmPlData *orig_lsm_pl_data = NULL;
+  guint i;
+
+  for (i = 0; i < lsm_pl_array->len; ++i)
+    {
+      lsm_pl = g_ptr_array_index (lsm_pl_array, i);
+      pl_id = lsm_pool_id_get (lsm_pl);
+      if ((pl_id == NULL) || (strlen (pl_id) == 0))
+        continue;
+
+      /* Overide old data  */
+      g_hash_table_lookup_extended (_pl_id_2_lsm_pl_data_hash, pl_id,
+                                    (gpointer *) &orig_pl_id,
+                                    (gpointer *) &orig_lsm_pl_data);
+      if (orig_pl_id != NULL)
+        g_hash_table_remove (_pl_id_2_lsm_pl_data_hash,
+                             (gconstpointer) orig_pl_id);
+
+      lsm_pl_data = (struct _LsmPlData *)
+        g_malloc (sizeof (struct _LsmPlData));
+
+      _fill_lsm_pl_data (lsm_pl_data, lsm_pl, last_refresh_time);
+      g_hash_table_insert (_pl_id_2_lsm_pl_data_hash,
+                           (gpointer) g_strdup (pl_id),
+                           (gpointer) lsm_pl_data);
+    }
+}
+
+/*
+ * Use lsm_conn_data to fill in these hash tables to speed up the future
+ * search:
+ *    _vpd83_2_lsm_conn_data_hash
+ *    _pl_id_2_lsm_pl_data_hash
+ */
+static void
+_fill_vpd83_2_lsm_conn_data_hash (lsm_connect *lsm_conn,
+                                  GPtrArray *lsm_vol_array)
+{
+  struct _LsmConnData *lsm_conn_data = NULL;
+  lsm_volume *lsm_vol = NULL;
+  const char *pl_id = NULL;
+  const char *vpd83 = NULL;
+  guint i;
+
+  for (i = 0; i < lsm_vol_array->len; ++i)
+    {
+      lsm_vol = g_ptr_array_index (lsm_vol_array, i);
+      if (lsm_vol == NULL)
+        continue;
+
+      vpd83 = lsm_volume_vpd83_get (lsm_vol);
+      if ((vpd83 == NULL) || (strlen (vpd83) == 0))
+        continue;
+
+      pl_id = lsm_volume_pool_id_get (lsm_vol);
+
+      if ((pl_id == NULL) || (strlen (pl_id) == 0))
+        continue;
+
+      lsm_conn_data = (struct _LsmConnData *)
+        g_malloc (sizeof (struct _LsmConnData));
+
+      lsm_conn_data->lsm_conn = lsm_conn;
+      lsm_conn_data->lsm_vol = lsm_volume_record_copy (lsm_vol);
+      if (lsm_conn_data->lsm_vol == NULL)
+        exit (1);   // No memory
+      lsm_conn_data->pl_id = g_strdup (pl_id);
+
+      g_hash_table_insert (_vpd83_2_lsm_conn_data_hash, g_strdup (vpd83),
+                           lsm_conn_data);
+    }
+}
+
+static void
+_fill_lsm_pl_data (struct _LsmPlData *lsm_pl_data, lsm_pool *lsm_pl,
+                   gint64 last_refresh_time)
+{
+  const char *lsm_pl_status_info = NULL;
+  uint64_t lsm_pl_status = 0;
+
+  lsm_pl_status = lsm_pool_status_get (lsm_pl);
+  lsm_pl_status_info = lsm_pool_status_info_get (lsm_pl);
+
+  lsm_pl_data->last_refresh_time = last_refresh_time;
+  lsm_pl_data->status_info = g_strdup (lsm_pl_status_info);
+
+  if (lsm_pl_status & LSM_POOL_STATUS_OK)
+    {
+      lsm_pl_data->is_ok = TRUE;
+    }
+  else
+    {
+      lsm_pl_data->is_ok = FALSE;
+    }
+
+  if (lsm_pl_status & LSM_POOL_STATUS_DEGRADED)
+    {
+      lsm_pl_data->is_raid_degraded = TRUE;
+      lsm_pl_data->is_ok = FALSE;
+    }
+  else
+    {
+      lsm_pl_data->is_raid_degraded = FALSE;
+    }
+
+  if (lsm_pl_status & LSM_POOL_STATUS_ERROR)
+    {
+      lsm_pl_data->is_raid_error = TRUE;
+      lsm_pl_data->is_ok = FALSE;
+    }
+  else
+    {
+      lsm_pl_data->is_raid_error = FALSE;
+    }
+
+  if (lsm_pl_status & LSM_POOL_STATUS_VERIFYING)
+    {
+      lsm_pl_data->is_raid_verifying = TRUE;
+      lsm_pl_data->is_ok = FALSE;
+    }
+  else
+    {
+      lsm_pl_data->is_raid_verifying = FALSE;
+    }
+
+  if (lsm_pl_status & LSM_POOL_STATUS_RECONSTRUCTING)
+    {
+      lsm_pl_data->is_raid_reconstructing = TRUE;
+      lsm_pl_data->is_ok = FALSE;
+    }
+  else
+    {
+      lsm_pl_data->is_raid_reconstructing = FALSE;
+    }
+  return;
+}
+
+
+/*
+ * Refresh _LsmVriData in _vpd83_2_lsm_vri_data_hash for certain VPD83.
+ * If volume has been delete, update _vpd83_2_lsm_conn_data_hash also to
+ * reflect that.
+ */
+static struct _LsmVriData *
+_refresh_lsm_vri_data (struct _LsmConnData *lsm_conn_data,
+                       const char *vpd83)
+{
+  struct _LsmVriData *lsm_vri_data = NULL;
+  const char *orig_vpd83 = NULL;
+  struct _LsmVriData *orig_lsm_vri_data = NULL;
+  struct _LsmConnData *orig_lsm_conn_data = NULL;
+  lsm_volume_raid_type raid_type;
+  uint32_t strip_size, disk_count, min_io_size, opt_io_size;
+  int lsm_rc;
+
+  // Remove _vpd83_2_lsm_vri_data_hash old entry
+  g_hash_table_lookup_extended (_vpd83_2_lsm_vri_data_hash, vpd83,
+                                (gpointer *) &orig_vpd83,
+                                (gpointer *) &orig_lsm_vri_data);
+  if (orig_vpd83 != NULL)
+    g_hash_table_remove (_vpd83_2_lsm_vri_data_hash,
+                         (gconstpointer) orig_vpd83);
+
+  lsm_rc = lsm_volume_raid_info (lsm_conn_data->lsm_conn,
+                                 lsm_conn_data->lsm_vol, &raid_type,
+                                 &strip_size, &disk_count, &min_io_size,
+                                 &opt_io_size, LSM_CLIENT_FLAG_RSVD);
+
+  if (lsm_rc != LSM_ERR_OK)
+    {
+      if (lsm_rc == LSM_ERR_NOT_FOUND_VOLUME)
+        storaged_debug ("LSM: Volume %s deleted", vpd83);
+      else
+        _handle_lsm_error ("LSM: Failed to retrieve RAID information "
+                           "of volume", lsm_conn_data->lsm_conn);
+
+      // Remove _vpd83_2_lsm_conn_data_hash entry
+      g_hash_table_lookup_extended (_vpd83_2_lsm_conn_data_hash, vpd83,
+                                    (gpointer *) &orig_vpd83,
+                                    (gpointer *) &orig_lsm_conn_data);
+
+      if (orig_vpd83 != NULL)
+        g_hash_table_remove (_vpd83_2_lsm_conn_data_hash,
+                             (gconstpointer) orig_vpd83);
+
+      return NULL;
+    }
+
+  lsm_vri_data = (struct _LsmVriData *) g_malloc (sizeof (struct _LsmVriData));
+  lsm_vri_data->raid_type_str =
+    g_strdup (_lsm_raid_type_to_str (raid_type));
+  lsm_vri_data->min_io_size = min_io_size;
+  lsm_vri_data->opt_io_size = opt_io_size;
+  lsm_vri_data->raid_disk_count = disk_count;
+  lsm_vri_data->last_refresh_time = g_get_monotonic_time ();
+
+  g_hash_table_insert (_vpd83_2_lsm_vri_data_hash, g_strdup (vpd83),
+                       lsm_vri_data);
+
+  return lsm_vri_data;
+}
+
+/*
+ * Check _pl_id_2_lsm_pl_data_hash and _vpd83_2_lsm_conn_data_hash hash table
+ * to find out the struct _LsmPlData.
+ * If data is outdated, try to update it.
+ */
+static struct _LsmPlData *
+_lsm_pl_data_lookup (const char *vpd83)
+{
+  struct _LsmConnData *lsm_conn_data = NULL;
+  struct _LsmPlData *lsm_pl_data = NULL;
+  GPtrArray *new_lsm_pl_array = NULL;
+  gint64 current_time = 0;
+  gint64 refresh_interval = 0;
+  const char *orig_pl_id;
+  struct _LsmPlData *orig_lsm_pl_data;
+
+  refresh_interval = std_lsm_refresh_time_get ();
+
+  if ((_vpd83_2_lsm_conn_data_hash == NULL) ||
+      (_pl_id_2_lsm_pl_data_hash == NULL))
+    return NULL;
+
+  lsm_conn_data = g_hash_table_lookup (_vpd83_2_lsm_conn_data_hash, vpd83);
+
+  if ((lsm_conn_data == NULL) || (lsm_conn_data->pl_id == NULL))
+    return NULL;
+
+  lsm_pl_data = g_hash_table_lookup (_pl_id_2_lsm_pl_data_hash,
+                                     lsm_conn_data->pl_id);
+
+  if (lsm_pl_data == NULL)
+    return NULL;
+
+  current_time = g_get_monotonic_time ();
+
+  if ((current_time - lsm_pl_data->last_refresh_time) / 1000000
+      < refresh_interval)
+    return lsm_pl_data;
+
+  // Refresh data is required.
+  storaged_debug ("LSM: Refreshing Pool(id %s) data", lsm_conn_data->pl_id);
+  new_lsm_pl_array = _get_supported_lsm_pls (lsm_conn_data->lsm_conn);
+  _fill_pl_id_2_lsm_pl_data_hash (new_lsm_pl_array, current_time);
+  g_ptr_array_unref (new_lsm_pl_array);
+
+  // Search again
+  lsm_pl_data = g_hash_table_lookup (_pl_id_2_lsm_pl_data_hash,
+                                     lsm_conn_data->pl_id);
+
+  if (_pl_id_2_lsm_pl_data_hash == NULL)
+    // Normally old data should not be delete yet.
+    return NULL;
+
+  if (lsm_pl_data->last_refresh_time != current_time)
+    {
+      storaged_debug ("LSM: _lsm_pl_data_lookup: pool deleted");
+
+      // Pool got deleted, we should delete the old data
+      g_hash_table_lookup_extended (_pl_id_2_lsm_pl_data_hash,
+                                    lsm_conn_data->pl_id,
+                                    (gpointer *) &orig_pl_id,
+                                    (gpointer *) &orig_lsm_pl_data);
+      if (orig_pl_id != NULL)
+        g_hash_table_remove (_pl_id_2_lsm_pl_data_hash,
+                             (gconstpointer) orig_pl_id);
+      return NULL;
+    }
+  return lsm_pl_data;
+}
+
+/*
+ * Search _vpd83_2_lsm_vri_data_hash, if not found or outdated, update it.
+ */
+static struct _LsmVriData *
+_lsm_vri_data_lookup (const char *vpd83)
+{
+  struct _LsmConnData *lsm_conn_data = NULL;
+  struct _LsmVriData *lsm_vri_data = NULL;
+  gint64 current_time = 0;
+  gint64 refresh_interval = 0;
+
+  refresh_interval = std_lsm_refresh_time_get ();
+
+  if (_vpd83_2_lsm_conn_data_hash == NULL)
+    return NULL;
+
+  lsm_conn_data = g_hash_table_lookup (_vpd83_2_lsm_conn_data_hash, vpd83);
+
+  if (lsm_conn_data == NULL)
+    return NULL;
+
+  lsm_vri_data = g_hash_table_lookup (_vpd83_2_lsm_vri_data_hash, vpd83);
+
+  current_time = g_get_monotonic_time ();
+
+  if ((lsm_vri_data != NULL) &&
+      ((current_time - lsm_vri_data->last_refresh_time) / 1000000
+        < refresh_interval))
+    return lsm_vri_data;
+
+  //Refresh data is required.
+  storaged_debug ("LSM: Refreshing VRI data for %s", vpd83);
+  return _refresh_lsm_vri_data (lsm_conn_data, vpd83);
+}
+
+static void
+_free_lsm_connect (gpointer data)
+{
+  lsm_connect_close ((lsm_connect *) data, LSM_CLIENT_FLAG_RSVD);
+}
+
+static void
+_free_lsm_uri_set (gpointer data)
+{
+  struct _LsmUriSet *lsm_uri_set = (struct _LsmUriSet *) data;
+  if (lsm_uri_set != NULL)
+    {
+      g_free ((gpointer) lsm_uri_set->uri);
+      g_free ((gpointer) lsm_uri_set->password);
+    }
+}
+
+static void
+_free_lsm_conn_data (gpointer data)
+{
+  struct _LsmConnData *lsm_conn_data = (struct _LsmConnData *) data;
+
+  if (lsm_conn_data != NULL)
+    {
+        lsm_volume_record_free (lsm_conn_data->lsm_vol);
+        g_free ((gpointer) lsm_conn_data->pl_id);
+        g_free ((gpointer) lsm_conn_data);
+    }
+}
+
+static void
+_free_lsm_pl_data (gpointer data)
+{
+  struct _LsmPlData *lsm_pl_data = (struct _LsmPlData *) data;
+
+  if (lsm_pl_data != NULL)
+    {
+      g_free ((gpointer) lsm_pl_data->status_info);
+      g_free ((gpointer) lsm_pl_data);
+    }
+}
+
+static void
+_free_lsm_vri_data (gpointer data)
+{
+  struct _LsmVriData *lsm_vri_data = (struct _LsmVriData *) data;
+
+  if (lsm_vri_data != NULL)
+    {
+      g_free ((gpointer) lsm_vri_data->raid_type_str);
+      g_free ((gpointer) lsm_vri_data);
+    }
+}
+
+void
+std_lsm_data_init (void)
+{
+  struct _LsmUriSet *lsm_uri_set = NULL;
+  lsm_connect *lsm_conn = NULL;
+  GPtrArray *lsm_vol_array = NULL;
+  GPtrArray *lsm_pl_array = NULL;
+  guint i = 0;
+  gboolean rc = FALSE;
+
+  _load_module_conf ();
+  if (_conf_lsm_uri_sets == NULL)
+    {
+      storaged_warning ("LSM: No URI found in config file %s",
+                        _STD_LSM_CONF_PATH);
+      return;
+    }
+
+  _all_lsm_conn_array =
+    g_ptr_array_new_full (0, (GDestroyNotify) _free_lsm_connect);
+
+  _vpd83_2_lsm_conn_data_hash =
+      g_hash_table_new_full (g_str_hash, g_str_equal,
+                            (GDestroyNotify) g_free,
+                            (GDestroyNotify) _free_lsm_conn_data);
+
+  _pl_id_2_lsm_pl_data_hash =
+      g_hash_table_new_full (g_str_hash, g_str_equal,
+                            (GDestroyNotify) g_free,
+                            (GDestroyNotify) _free_lsm_pl_data);
+
+  _vpd83_2_lsm_vri_data_hash =
+      g_hash_table_new_full (g_str_hash, g_str_equal,
+                             (GDestroyNotify) g_free,
+                             (GDestroyNotify) _free_lsm_vri_data);
+
+  _supported_sys_id_hash =
+      g_hash_table_new_full (g_str_hash, g_str_equal,
+                             (GDestroyNotify) g_free,
+                             NULL);
+
+  for (i =0; i < _conf_lsm_uri_sets->len; ++i)
+    {
+      lsm_uri_set = g_ptr_array_index (_conf_lsm_uri_sets, i);
+      lsm_conn = _create_lsm_connect (lsm_uri_set);
+      if (lsm_conn == NULL)
+        continue;
+      rc = _fill_supported_system_id_hash (lsm_conn);
+      if (rc != TRUE)
+        {
+          lsm_connect_close (lsm_conn, LSM_CLIENT_FLAG_RSVD);
+          continue;
+        }
+      g_ptr_array_add (_all_lsm_conn_array, lsm_conn);
+
+      lsm_vol_array = _get_supported_lsm_volumes (lsm_conn);
+      if (lsm_vol_array == NULL)
+        {
+          continue;
+        }
+      lsm_pl_array = _get_supported_lsm_pls (lsm_conn);
+
+      _fill_pl_id_2_lsm_pl_data_hash (lsm_pl_array, g_get_monotonic_time ());
+      _fill_vpd83_2_lsm_conn_data_hash (lsm_conn, lsm_vol_array);
+      g_ptr_array_unref (lsm_vol_array);
+      g_ptr_array_unref (lsm_pl_array);
+    }
+}
+
+uint32_t
+std_lsm_refresh_time_get (void)
+{
+  return _conf_refresh_interval;
+}
+
+/*
+ * Return struct StdLsmVolData for given VPD83.
+ * The memory should be freeed by std_lsm_vol_data_free ().
+ */
+struct StdLsmVolData *
+std_lsm_vol_data_get (const char *vpd83)
+{
+  struct StdLsmVolData *std_lsm_vol_data = NULL;
+  struct _LsmPlData *lsm_pl_data = NULL;
+  struct _LsmVriData *lsm_vri_data = NULL;
+
+  lsm_pl_data = _lsm_pl_data_lookup (vpd83);
+  if (lsm_pl_data == NULL)
+    goto out;
+
+  lsm_vri_data = _lsm_vri_data_lookup (vpd83);
+  if (lsm_vri_data == NULL)
+    goto out;
+
+  std_lsm_vol_data = (struct StdLsmVolData *) g_malloc
+    (sizeof (struct StdLsmVolData));
+
+  strncpy (std_lsm_vol_data->raid_type, lsm_vri_data->raid_type_str,
+           _MAX_RAID_TYPE_LEN);
+  std_lsm_vol_data->raid_type[_MAX_RAID_TYPE_LEN - 1] = '\0';
+
+  strncpy (std_lsm_vol_data->status_info, lsm_pl_data->status_info,
+           _MAX_STATUS_INFO_LEN);
+
+  std_lsm_vol_data->status_info[_MAX_STATUS_INFO_LEN - 1] = '\0';
+
+  std_lsm_vol_data->is_raid_degraded = lsm_pl_data->is_raid_degraded;
+  std_lsm_vol_data->is_raid_reconstructing =
+    lsm_pl_data->is_raid_reconstructing;
+  std_lsm_vol_data->is_raid_verifying = lsm_pl_data->is_raid_verifying;
+  std_lsm_vol_data->is_raid_error = lsm_pl_data->is_raid_error;
+  std_lsm_vol_data->is_ok = lsm_pl_data->is_ok;
+  std_lsm_vol_data->min_io_size = lsm_vri_data->min_io_size;
+  std_lsm_vol_data->opt_io_size = lsm_vri_data->opt_io_size;
+  std_lsm_vol_data->raid_disk_count = lsm_vri_data->raid_disk_count;
+
+out:
+  return std_lsm_vol_data;
+
+}
+
+void
+std_lsm_vol_data_free (struct StdLsmVolData *std_lsm_vol_data)
+{
+  g_free ((gpointer) std_lsm_vol_data);
+}
+
+void
+std_lsm_data_teardown (void)
+{
+  g_ptr_array_unref (_conf_lsm_uri_sets);
+  _conf_lsm_uri_sets = NULL;
+
+  g_hash_table_unref (_supported_sys_id_hash);
+  _supported_sys_id_hash = NULL;
+
+  g_ptr_array_unref (_all_lsm_conn_array);
+  _all_lsm_conn_array = NULL;
+
+  g_hash_table_unref (_vpd83_2_lsm_conn_data_hash);
+  _vpd83_2_lsm_conn_data_hash = NULL;
+
+  g_hash_table_unref (_vpd83_2_lsm_vri_data_hash);
+  _vpd83_2_lsm_vri_data_hash = NULL;
+
+  g_hash_table_unref (_pl_id_2_lsm_pl_data_hash);
+  _pl_id_2_lsm_pl_data_hash = NULL;
+}
+
+void
+std_lsm_vpd83_list_refresh (void)
+{
+  lsm_connect *lsm_conn = NULL;
+  GPtrArray *lsm_pl_array = NULL;
+  GPtrArray *lsm_vol_array = NULL;
+  guint i;
+
+  storaged_debug ("LSM: std_lsm_vpd83_list_refresh ()");
+
+  if (_all_lsm_conn_array == NULL )
+    return;
+
+  /* free old data:
+   *  _vpd83_2_lsm_conn_data_hash
+   *  _pl_id_2_lsm_pl_data_hash
+   */
+  g_hash_table_remove_all (_vpd83_2_lsm_conn_data_hash);
+  g_hash_table_remove_all (_pl_id_2_lsm_pl_data_hash);
+
+  for (i = 0; i < _all_lsm_conn_array->len; ++i)
+    {
+      lsm_conn = g_ptr_array_index (_all_lsm_conn_array, i);
+      if (lsm_conn == NULL)
+        continue;
+
+      lsm_vol_array = _get_supported_lsm_volumes (lsm_conn);
+      if (lsm_vol_array == NULL)
+        continue;
+      lsm_pl_array = _get_supported_lsm_pls (lsm_conn);
+
+      _fill_pl_id_2_lsm_pl_data_hash (lsm_pl_array, g_get_monotonic_time ());
+      _fill_vpd83_2_lsm_conn_data_hash (lsm_conn, lsm_vol_array);
+      g_ptr_array_unref (lsm_vol_array);
+      g_ptr_array_unref (lsm_pl_array);
+    }
+}
+
+gboolean
+std_lsm_vpd83_is_managed (const char *vpd83)
+{
+  if ((vpd83 != NULL) &&
+      (_vpd83_2_lsm_conn_data_hash != NULL) &&
+      g_hash_table_lookup (_vpd83_2_lsm_conn_data_hash, vpd83))
+    return TRUE;
+  return FALSE;
+}

--- a/modules/lsm/lsm_data.h
+++ b/modules/lsm/lsm_data.h
@@ -1,0 +1,80 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ *
+ */
+
+/*
+ * This file contains:
+ *  1. LSM data to storaged interface data converting.
+ *  2. Provide simple abstracted interface of LSM to storaged codes.
+ */
+
+#ifndef __LSM_DATA_H__
+#define __LSM_DATA_H__
+
+#include <libstoragemgmt/libstoragemgmt.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <glib.h>
+
+//#include <libconfig.h>
+
+G_BEGIN_DECLS
+
+#define _MAX_RAID_TYPE_LEN 10
+#define _MAX_STATUS_INFO_LEN 255
+
+struct StdLsmVolData
+{
+  char raid_type[_MAX_RAID_TYPE_LEN];
+  char status_info[_MAX_STATUS_INFO_LEN];
+  gboolean is_raid_degraded;
+  gboolean is_raid_reconstructing;
+  gboolean is_raid_verifying;
+  gboolean is_raid_error;
+  gboolean is_ok;
+  uint32_t min_io_size;
+  uint32_t opt_io_size;
+  uint32_t raid_disk_count;
+};
+
+void std_lsm_data_init (void);
+
+/*
+ * The cached lsm volume/vpd83 list will not refresh automatically. This is
+ * might cause new volume get incorrectly marked as not managed by
+ * std_lsm_vol_data_get ().
+ * This method is used to manually refresh that cache.
+ */
+void std_lsm_vpd83_list_refresh (void);
+
+void std_lsm_data_teardown (void);
+
+struct StdLsmVolData *std_lsm_vol_data_get (const char *vpd83);
+
+void std_lsm_vol_data_free (struct StdLsmVolData *std_lsm_vol_data);
+
+uint32_t std_lsm_refresh_time_get (void);
+
+gboolean std_lsm_vpd83_is_managed (const char *vpd83);
+
+G_END_DECLS
+#endif /* __LSM_DATA_H__ */

--- a/modules/lsm/lsm_linux_drive.c
+++ b/modules/lsm/lsm_linux_drive.c
@@ -1,0 +1,370 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Gris Ge <fge@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Note: This is inspired by modules/dummy/dummylinuxdrive.c  */
+
+#include "config.h"
+
+#include <sys/types.h>
+
+#include <pwd.h>
+#include <grp.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <glib.h>
+#include <libstoragemgmt/libstoragemgmt.h>
+
+#include <src/storagedlogging.h>
+#include <src/storagedlinuxdriveobject.h>
+#include <src/storagedlinuxblockobject.h>
+#include <src/storageddaemon.h>
+#include <src/storageddaemonutil.h>
+#include <src/storagedbasejob.h>
+#include <src/storagedsimplejob.h>
+#include <src/storagedthreadedjob.h>
+#include <src/storagedlinuxdevice.h>
+#include <modules/storagedmoduleobject.h>
+
+#include "lsm_data.h"
+#include "lsm_types.h"
+
+static void
+_fill_std_lx_drv_lsm (StoragedLinuxDriveLSM *std_lx_drv_lsm,
+                   struct StdLsmVolData *lsm_vol_data);
+
+static gboolean
+_is_std_lsm_vol_data_changed (struct StdLsmVolData *old_lsm_data,
+                              struct StdLsmVolData *new_lsm_data,
+                              StoragedLinuxDriveLSM *std_lx_drv_lsm);
+
+static gboolean _on_refresh_data (StoragedLinuxDriveLSM *std_lx_drv_lsm);
+
+typedef struct _StoragedLinuxDriveLSMClass StoragedLinuxDriveLSMClass;
+
+struct _StoragedLinuxDriveLSM
+{
+  StoragedDriveLSMSkeleton parent_instance;
+  struct StdLsmVolData *old_lsm_data;
+  StoragedLinuxDriveObject *std_lx_drv_obj;
+  const char *vpd83;
+  GSource *loop_source;
+};
+
+struct _StoragedLinuxDriveLSMClass
+{
+  StoragedDriveLSMSkeletonClass parent_class;
+};
+
+static void
+storaged_linux_drive_lsm_iface_init (StoragedDriveLSMIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE
+  (StoragedLinuxDriveLSM, storaged_linux_drive_lsm,
+   STORAGED_TYPE_DRIVE_LSM_SKELETON,
+   G_IMPLEMENT_INTERFACE (STORAGED_TYPE_DRIVE_LSM,
+                          storaged_linux_drive_lsm_iface_init));
+
+static void
+_free_std_lx_drv_lsm_content (StoragedLinuxDriveLSM *std_lx_drv_lsm);
+
+
+static void
+_free_std_lx_drv_lsm_content (StoragedLinuxDriveLSM *std_lx_drv_lsm)
+{
+  if (std_lx_drv_lsm == NULL)
+    return;
+
+  if (std_lx_drv_lsm->loop_source != NULL)
+    {
+      storaged_debug ("LSM: _free_std_lx_drv_lsm_content (): "
+                        "destroying loop source");
+
+      g_free ((gpointer) std_lx_drv_lsm->vpd83);
+      std_lsm_vol_data_free (std_lx_drv_lsm->old_lsm_data);
+      g_object_remove_weak_pointer
+        ((GObject *) std_lx_drv_lsm->std_lx_drv_obj,
+         (gpointer *) &std_lx_drv_lsm->std_lx_drv_obj);
+      g_source_destroy (std_lx_drv_lsm->loop_source);
+      g_source_unref (std_lx_drv_lsm->loop_source);
+      /* Setting loop_source as NULL here just in case this method
+       * is call by _on_refresh_data ().
+       * As g_dbus_object_skeleton_add_interface () still hold reference
+       * to std_lx_drv_lsm, it might possible
+       * storaged_linux_drive_lsm_update () add every thing back again.
+       */
+      std_lx_drv_lsm->loop_source = NULL;
+
+      if (G_IS_DBUS_OBJECT_SKELETON (std_lx_drv_lsm->std_lx_drv_obj) &&
+          G_IS_DBUS_INTERFACE_SKELETON (std_lx_drv_lsm) &&
+          g_dbus_object_get_interface
+          ((GDBusObject *) std_lx_drv_lsm->std_lx_drv_obj,
+           "org.storaged.Storaged.Drive.LSM"))
+        {
+          g_dbus_object_skeleton_remove_interface
+              (G_DBUS_OBJECT_SKELETON (std_lx_drv_lsm->std_lx_drv_obj),
+               G_DBUS_INTERFACE_SKELETON (std_lx_drv_lsm));
+        }
+    }
+}
+
+
+static void
+storaged_linux_drive_lsm_finalize (GObject *object)
+{
+  storaged_debug ("LSM: storaged_linux_drive_lsm_finalize ()");
+
+  if ((object != NULL) && (STORAGED_IS_LINUX_DRIVE_LSM (object)))
+    _free_std_lx_drv_lsm_content (STORAGED_LINUX_DRIVE_LSM (object));
+
+  if (G_OBJECT_CLASS (storaged_linux_drive_lsm_parent_class)->finalize != NULL)
+    G_OBJECT_CLASS (storaged_linux_drive_lsm_parent_class)->finalize (object);
+}
+
+
+static void
+storaged_linux_drive_lsm_init (StoragedLinuxDriveLSM *std_lx_drv_lsm)
+{
+  storaged_debug ("LSM: storaged_linux_drive_lsm_init");
+
+  std_lx_drv_lsm->old_lsm_data = NULL;
+  std_lx_drv_lsm->std_lx_drv_obj = NULL;
+  std_lx_drv_lsm->vpd83 = NULL;
+  std_lx_drv_lsm->loop_source = NULL;
+  return;
+}
+
+static void
+storaged_linux_drive_lsm_class_init (StoragedLinuxDriveLSMClass *class)
+{
+  GObjectClass *gobject_class;
+
+  storaged_debug ("LSM: storaged_linux_drive_lsm_class_init");
+  gobject_class = G_OBJECT_CLASS (class);
+  gobject_class->finalize = storaged_linux_drive_lsm_finalize;
+}
+
+static void
+_fill_std_lx_drv_lsm (StoragedLinuxDriveLSM *std_lx_drv_lsm,
+                   struct StdLsmVolData *lsm_vol_data)
+{
+  StoragedDriveLSM *std_drv_lsm = STORAGED_DRIVE_LSM (std_lx_drv_lsm);
+
+  if (lsm_vol_data == NULL)
+    return;
+
+  storaged_drive_lsm_set_status_info
+    (std_drv_lsm, lsm_vol_data->status_info);
+  storaged_drive_lsm_set_raid_type
+    (std_drv_lsm, lsm_vol_data->raid_type);
+  storaged_drive_lsm_set_is_ok
+    (std_drv_lsm, lsm_vol_data->is_ok);
+  storaged_drive_lsm_set_is_raid_degraded
+    (std_drv_lsm, lsm_vol_data->is_raid_degraded);
+  storaged_drive_lsm_set_is_raid_error
+    (std_drv_lsm, lsm_vol_data->is_raid_error);
+  storaged_drive_lsm_set_is_raid_verifying
+    (std_drv_lsm, lsm_vol_data->is_raid_verifying);
+  storaged_drive_lsm_set_is_raid_reconstructing
+    (std_drv_lsm, lsm_vol_data->is_raid_reconstructing);
+  storaged_drive_lsm_set_min_io_size
+    (std_drv_lsm, lsm_vol_data->min_io_size);
+  storaged_drive_lsm_set_opt_io_size
+    (std_drv_lsm, lsm_vol_data->opt_io_size);
+  storaged_drive_lsm_set_raid_disk_count
+    (std_drv_lsm, lsm_vol_data->raid_disk_count);
+}
+
+
+/*
+ * Compare old data and new data. Return TRUE if changed.
+ */
+static gboolean
+_is_std_lsm_vol_data_changed (struct StdLsmVolData *old_lsm_data,
+                              struct StdLsmVolData *new_lsm_data,
+                              StoragedLinuxDriveLSM *std_lx_drv_lsm)
+{
+  if ((old_lsm_data == NULL || new_lsm_data == NULL))
+    {
+      storaged_warning ("LSM: BUG: _is_std_lsm_vol_data_changed () got NULL "
+                        "old_lsm_data or NULL new_lsm_data "
+                        "which should not happen");
+      return TRUE;
+    }
+
+  if ((strcmp (old_lsm_data->status_info, new_lsm_data->status_info) != 0) ||
+      (strcmp (old_lsm_data->raid_type, new_lsm_data->raid_type) != 0) ||
+      (old_lsm_data->is_ok != new_lsm_data->is_ok) ||
+      (old_lsm_data->is_raid_degraded != new_lsm_data->is_raid_degraded) ||
+      (old_lsm_data->is_raid_error != new_lsm_data->is_raid_error) ||
+      (old_lsm_data->is_raid_verifying != new_lsm_data->is_raid_verifying) ||
+      (old_lsm_data->is_raid_reconstructing !=
+       new_lsm_data->is_raid_reconstructing) ||
+      (old_lsm_data->min_io_size != new_lsm_data->min_io_size) ||
+      (old_lsm_data->opt_io_size != new_lsm_data->opt_io_size) ||
+      (old_lsm_data->raid_disk_count != new_lsm_data->raid_disk_count))
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
+_on_refresh_data (StoragedLinuxDriveLSM *std_lx_drv_lsm)
+{
+  struct StdLsmVolData *new_lsm_data = NULL;
+
+  if ((std_lx_drv_lsm == NULL) ||
+      (std_lx_drv_lsm->std_lx_drv_obj == NULL) ||
+      (! STORAGED_IS_LINUX_DRIVE_LSM (std_lx_drv_lsm)) ||
+      (! STORAGED_IS_LINUX_DRIVE_OBJECT (std_lx_drv_lsm->std_lx_drv_obj)))
+    goto remove_out;
+
+  storaged_debug ("LSM: Refreshing LSM RAID info for VPD83/WWN %s",
+                  std_lx_drv_lsm->vpd83);
+
+  new_lsm_data = std_lsm_vol_data_get (std_lx_drv_lsm->vpd83);
+
+  if (new_lsm_data == NULL)
+    {
+      storaged_debug ("LSM: Disk drive VPD83/WWN %s is not LSM managed "
+                      "any more", std_lx_drv_lsm->vpd83);
+      goto remove_out;
+    }
+
+  if (_is_std_lsm_vol_data_changed (std_lx_drv_lsm->old_lsm_data, new_lsm_data,
+                                    std_lx_drv_lsm))
+    {
+      _fill_std_lx_drv_lsm (std_lx_drv_lsm, new_lsm_data);
+      std_lsm_vol_data_free (std_lx_drv_lsm->old_lsm_data);
+      std_lx_drv_lsm->old_lsm_data = new_lsm_data;
+    }
+  else
+    std_lsm_vol_data_free (new_lsm_data);
+
+  return TRUE;
+
+remove_out:
+  /* As g_dbus_object_skeleton_add_interface () in update_iface () of
+   * src/storagedlinuxdriveobject.c take its own reference to std_lx_drv_lsm,
+   * g_object_unref (std_drv_Lsm) here does not cause trigger
+   * storaged_linux_drive_lsm_finalize () to remove dbus interface.
+   * Hence we have to remove dbus interface and loop related resources here.
+   */
+  if STORAGED_IS_LINUX_DRIVE_LSM (std_lx_drv_lsm)
+    {
+      _free_std_lx_drv_lsm_content (std_lx_drv_lsm);
+      g_object_unref (std_lx_drv_lsm);
+    }
+
+  if (new_lsm_data != NULL)
+    std_lsm_vol_data_free (new_lsm_data);
+  return FALSE;
+}
+
+static void
+storaged_linux_drive_lsm_iface_init (StoragedDriveLSMIface *iface)
+{
+  storaged_debug ("LSM: storaged_linux_drive_lsm_iface_init");
+}
+
+StoragedLinuxDriveLSM *
+storaged_linux_drive_lsm_new (void)
+{
+  storaged_debug ("LSM: storaged_linux_drive_lsm_new");
+  return STORAGED_LINUX_DRIVE_LSM (g_object_new (STORAGED_TYPE_DRIVE_LSM,
+                                                 NULL));
+}
+
+gboolean
+storaged_linux_drive_lsm_update (StoragedLinuxDriveLSM *std_lx_drv_lsm,
+                                 StoragedLinuxDriveObject *std_lx_drv_obj)
+{
+  struct StdLsmVolData *lsm_vol_data = NULL;
+  StoragedLinuxDevice *st_lx_dev;
+  const gchar *wwn = NULL;
+  gboolean rc = FALSE;
+
+  storaged_debug ("LSM: storaged_linux_drive_lsm_update");
+
+  if (std_lx_drv_lsm->loop_source != NULL)
+    {
+      storaged_debug ("LSM: Already in refresh loop");
+      return FALSE;
+    }
+
+  st_lx_dev = storaged_linux_drive_object_get_device (std_lx_drv_obj, TRUE);
+  if (st_lx_dev == NULL)
+    {
+      storaged_debug ("LSM: storaged_linux_drive_lsm_update (): Got NULL "
+                      "storaged_linux_drive_object_get_device () return");
+      goto out;
+    }
+
+  wwn = g_udev_device_get_property (st_lx_dev->udev_device,
+                                    "ID_WWN_WITH_EXTENSION");
+  if ((!wwn) || (strlen (wwn) < 2))
+    {
+      storaged_debug ("LSM: storaged_linux_drive_lsm_update (): Got emtpy "
+                      "ID_WWN_WITH_EXTENSION dbus property");
+      goto out;
+    }
+
+  // Udev ID_WWN is started with 0x.
+  lsm_vol_data = std_lsm_vol_data_get (wwn + 2);
+
+  if (lsm_vol_data == NULL)
+    {
+      storaged_debug ("LSM: VPD %s is not managed by LibstorageMgmt",
+                      wwn + 2 );
+      goto out;
+    }
+
+  storaged_debug ("LSM: VPD %s is managed by LibstorageMgmt", wwn + 2 );
+
+  _fill_std_lx_drv_lsm (std_lx_drv_lsm, lsm_vol_data);
+
+  /* Don't free lsm_vol_data, it is managed by
+   * storaged_linux_drive_lsm_finalize ().
+   */
+  std_lx_drv_lsm->old_lsm_data = lsm_vol_data;
+  std_lx_drv_lsm->std_lx_drv_obj = std_lx_drv_obj;
+  std_lx_drv_lsm->vpd83 = g_strdup (wwn + 2);
+  g_object_add_weak_pointer ((GObject *) std_lx_drv_obj,
+                             (gpointer *) &std_lx_drv_lsm->std_lx_drv_obj);
+  std_lx_drv_lsm->loop_source =
+    g_timeout_source_new_seconds (std_lsm_refresh_time_get ());
+  g_source_set_callback (std_lx_drv_lsm->loop_source,
+                         (GSourceFunc) _on_refresh_data,
+                         (gpointer) std_lx_drv_lsm, NULL);
+  g_source_attach (std_lx_drv_lsm->loop_source, NULL);
+
+  storaged_debug ("LSM: VPD83 %s added to refresh event loop", wwn + 2);
+
+  rc = TRUE;
+
+out:
+  if (st_lx_dev != NULL)
+    g_object_unref (st_lx_dev);
+
+  if (rc == FALSE)
+    g_object_unref (std_lx_drv_lsm);
+
+  return rc;
+}

--- a/modules/lsm/lsm_linux_manager.c
+++ b/modules/lsm/lsm_linux_manager.c
@@ -1,0 +1,80 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Gris Ge <fge@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Note: This file is inspired by modules/dummy/dummylinuxmanager.c  */
+
+#include "config.h"
+
+#include <sys/types.h>
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <src/storagedlogging.h>
+#include <src/storageddaemon.h>
+#include <src/storageddaemonutil.h>
+#include <src/storagedlinuxdevice.h>
+
+#include "lsm_types.h"
+
+typedef struct _StoragedLinuxManagerLSMClass StoragedLinuxManagerLSMClass;
+
+struct _StoragedLinuxManagerLSM
+{
+  StoragedManagerLSMSkeleton parent_instance;
+};
+
+struct _StoragedLinuxManagerLSMClass
+{
+  StoragedManagerLSMSkeletonClass parent_class;
+};
+
+static void
+storaged_linux_manager_lsm_iface_init (StoragedManagerLSMIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE
+  (StoragedLinuxManagerLSM, storaged_linux_manager_lsm,
+   STORAGED_TYPE_MANAGER_LSM_SKELETON,
+   G_IMPLEMENT_INTERFACE (STORAGED_TYPE_MANAGER_LSM,
+                          storaged_linux_manager_lsm_iface_init));
+
+static void
+storaged_linux_manager_lsm_init (StoragedLinuxManagerLSM *manager)
+{
+}
+
+static void
+storaged_linux_manager_lsm_class_init (StoragedLinuxManagerLSMClass *class)
+{
+}
+
+StoragedLinuxManagerLSM *
+storaged_linux_manager_lsm_new (void)
+{
+  return STORAGED_LINUX_MANAGER_LSM
+    (g_object_new (STORAGED_TYPE_LINUX_MANAGER_LSM, NULL));
+}
+
+static void
+storaged_linux_manager_lsm_iface_init (StoragedManagerLSMIface *iface)
+{
+  // Empty but need to force storaged do coldplug refresh all interface.
+}

--- a/modules/lsm/lsm_module_iface.c
+++ b/modules/lsm/lsm_module_iface.c
@@ -1,0 +1,213 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Gris Ge <fge@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+
+#include <modules/storagedmoduleiface.h>
+
+#include <storaged/storaged-generated.h>
+#include <src/storagedlinuxblockobject.h>
+#include <src/storagedlinuxdriveobject.h>
+#include <src/storagedlinuxdevice.h>
+
+#include "lsm_types.h"
+#include "lsm_data.h"
+
+#define _UDEV_ACTION_ADD        "add"
+#define _UDEV_ACTION_REMOVE     "remove"
+#define _UDEV_ACTION_CHANGE     "change"
+#define _UDEV_ACTION_ONLINE     "online"
+#define _UDEV_ACTION_OFFLINE    "offline"
+
+gchar *
+storaged_module_id (void)
+{
+  return g_strdup (LSM_MODULE_NAME);
+}
+
+gpointer
+storaged_module_init (StoragedDaemon *daemon)
+{
+  storaged_debug ("LSM: storaged_module_init ()");
+  std_lsm_data_init ();
+  return NULL;
+}
+
+void
+storaged_module_teardown (StoragedDaemon *daemon)
+{
+  storaged_debug ("LSM: storaged_module_teardown ()");
+  std_lsm_data_teardown ();
+}
+
+static gboolean
+_drive_check (StoragedObject *object)
+{
+  gboolean is_managed = FALSE;
+  StoragedLinuxDriveObject *std_lx_drv_obj = NULL;
+  StoragedLinuxDevice *st_lx_dev = NULL;
+  gboolean rc = FALSE;
+  const gchar *wwn = NULL;
+
+  storaged_debug ("LSM: _drive_check");
+  std_lx_drv_obj = STORAGED_LINUX_DRIVE_OBJECT (object);
+
+  st_lx_dev = storaged_linux_drive_object_get_device (std_lx_drv_obj, TRUE);
+  if (st_lx_dev == NULL)
+    {
+      goto out;
+    }
+
+  if (g_udev_device_get_property_as_boolean (st_lx_dev->udev_device,
+                                             "ID_CDROM"))
+    goto out;
+
+  wwn = g_udev_device_get_property (st_lx_dev->udev_device,
+                                    "ID_WWN_WITH_EXTENSION");
+  if ((!wwn) || (strlen (wwn) < 2))
+    goto out;
+
+  // Udev ID_WWN is started with 0x.
+  is_managed = std_lsm_vpd83_is_managed (wwn + 2);
+
+  if (is_managed == FALSE)
+    {
+      // Refresh and try again.
+      std_lsm_vpd83_list_refresh ();
+      is_managed = std_lsm_vpd83_is_managed (wwn + 2);
+    }
+
+  if (is_managed == FALSE)
+    {
+      storaged_debug ("LSM: VPD %s is not managed by LibstorageMgmt",
+                      wwn + 2 );
+      goto out;
+    }
+  else
+    rc = TRUE;
+
+out:
+  if (st_lx_dev != NULL)
+    g_object_unref (st_lx_dev);
+
+  return rc;
+}
+
+static void
+_drive_connect (StoragedObject *object)
+{
+}
+
+static gboolean
+_drive_update (StoragedObject *object,
+               const gchar *uevent_action, GDBusInterface *_iface)
+{
+  storaged_debug ("LSM: _drive_update: got udevent_action %s", uevent_action);
+
+  if (strcmp (uevent_action, _UDEV_ACTION_ADD) == 0)
+    {
+      return storaged_linux_drive_lsm_update
+        (STORAGED_LINUX_DRIVE_LSM (_iface),
+         STORAGED_LINUX_DRIVE_OBJECT (object));
+    }
+  else if (strcmp (uevent_action, _UDEV_ACTION_CHANGE) == 0)
+    {
+      /* Some LibStorageMgmt actions(like HPSA) might cause change uevent
+       * we should ignore them to avoid check loop.
+       */
+      return FALSE;
+    }
+  else if (strcmp (uevent_action, _UDEV_ACTION_ONLINE) == 0)
+    {
+      // disk became online via sysfs, ignore
+      return FALSE;
+    }
+  else if (strcmp (uevent_action, _UDEV_ACTION_OFFLINE) == 0)
+    {
+      // disk became offline via sysfs, ignore
+      return FALSE;
+    }
+  else if (strcmp (uevent_action, _UDEV_ACTION_REMOVE) == 0)
+    {
+      if (STORAGED_IS_LINUX_DRIVE_LSM (_iface))
+        g_object_unref (STORAGED_LINUX_DRIVE_LSM (_iface));
+      return TRUE;
+    }
+  else
+    {
+      storaged_warning ("LSM: BUG: Got unknown udev action: %s, ignoring",
+                        (const char *) uevent_action);
+      return FALSE;
+    }
+}
+
+StoragedModuleInterfaceInfo **
+storaged_module_get_block_object_iface_setup_entries (void)
+{
+  return NULL;
+}
+
+StoragedModuleInterfaceInfo **
+storaged_module_get_drive_object_iface_setup_entries (void)
+{
+  StoragedModuleInterfaceInfo **iface;
+
+  iface = g_new0 (StoragedModuleInterfaceInfo *, 2);
+  iface[0] = g_new0 (StoragedModuleInterfaceInfo, 1);
+  iface[0]->has_func = &_drive_check;
+  iface[0]->connect_func = &_drive_connect;
+  iface[0]->update_func = &_drive_update;
+  iface[0]->skeleton_type = STORAGED_TYPE_LINUX_DRIVE_LSM;
+
+  return iface;
+}
+
+StoragedModuleObjectNewFunc *
+storaged_module_get_object_new_funcs (void)
+{
+  return NULL;
+}
+
+static GDBusInterfaceSkeleton *
+_manager_iface_new (StoragedDaemon *daemon)
+{
+  StoragedLinuxManagerLSM *manager;
+
+  manager = storaged_linux_manager_lsm_new ();
+
+  return G_DBUS_INTERFACE_SKELETON (manager);
+}
+
+StoragedModuleNewManagerIfaceFunc *
+storaged_module_get_new_manager_iface_funcs (void)
+{
+  StoragedModuleNewManagerIfaceFunc *funcs = NULL;
+  funcs = g_new0 (StoragedModuleNewManagerIfaceFunc, 2);
+  funcs[0] = &_manager_iface_new;
+
+  return funcs;
+}

--- a/modules/lsm/lsm_types.h
+++ b/modules/lsm/lsm_types.h
@@ -1,0 +1,69 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Gris Ge <fge@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __LSM_TYPES_H__
+#define __LSM_TYPES_H__
+
+#include <gio/gio.h>
+#include <polkit/polkit.h>
+#include <storaged/storaged.h>
+#include <gudev/gudev.h>
+#include <sys/types.h>
+#include <src/storagedlogging.h>
+
+#include "lsm_generated.h"
+
+G_BEGIN_DECLS
+
+#define LSM_MODULE_NAME "lsm"
+
+struct _StoragedLinuxDriveLSM;
+typedef struct _StoragedLinuxDriveLSM StoragedLinuxDriveLSM;
+
+#define STORAGED_TYPE_LINUX_DRIVE_LSM (storaged_linux_drive_lsm_get_type ())
+#define STORAGED_LINUX_DRIVE_LSM(o) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), STORAGED_TYPE_LINUX_DRIVE_LSM, \
+                               StoragedLinuxDriveLSM))
+#define STORAGED_IS_LINUX_DRIVE_LSM(o) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((o), STORAGED_TYPE_LINUX_DRIVE_LSM))
+
+GType storaged_linux_drive_lsm_get_type (void) G_GNUC_CONST;
+StoragedLinuxDriveLSM *storaged_linux_drive_lsm_new (void);
+gboolean
+storaged_linux_drive_lsm_update (StoragedLinuxDriveLSM *std_lx_drv_lsm,
+                                 StoragedLinuxDriveObject *st_lx_drv_obj);
+
+struct _StoragedLinuxManagerLSM;
+typedef struct _StoragedLinuxManagerLSM StoragedLinuxManagerLSM;
+
+#define STORAGED_TYPE_LINUX_MANAGER_LSM \
+  (storaged_linux_manager_lsm_get_type ())
+#define STORAGED_LINUX_MANAGER_LSM(o) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), STORAGED_TYPE_LINUX_MANAGER_LSM, \
+                               StoragedLinuxManagerLSM))
+#define STORAGED_IS_LINUX_MANAGER_LSM(o) \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((o), STORAGED_TYPE_LINUX_MANAGER))
+
+GType storaged_linux_manager_lsm_get_type (void) G_GNUC_CONST;
+StoragedLinuxManagerLSM *storaged_linux_manager_lsm_new (void);
+
+G_END_DECLS
+
+#endif /* __LSM_TYPES_H__ */

--- a/rpm_dependencies.txt
+++ b/rpm_dependencies.txt
@@ -13,3 +13,5 @@ libblockdev-swap-devel
 libgudev1-devel
 lvm2-devel
 polkit-devel
+libstoragemgmt-devel
+libconfig-devel

--- a/src/storagedlinuxdriveobject.c
+++ b/src/storagedlinuxdriveobject.c
@@ -496,6 +496,7 @@ update_iface (StoragedObject                     *object,
   gboolean has;
   gboolean add;
   GDBusInterface **interface_pointer = _interface_pointer;
+  GDBusInterfaceInfo *interface_info = NULL;
 
   g_return_val_if_fail (object != NULL, FALSE);
   g_return_val_if_fail (has_func != NULL, FALSE);
@@ -521,8 +522,15 @@ update_iface (StoragedObject                     *object,
     {
       if (!has)
         {
-          g_dbus_object_skeleton_remove_interface (G_DBUS_OBJECT_SKELETON (object),
-                                                   G_DBUS_INTERFACE_SKELETON (*interface_pointer));
+          /* Check before we remove interface from object  */
+          interface_info = g_dbus_interface_get_info (*interface_pointer);
+
+          if (g_dbus_object_get_interface ((GDBusObject *) object,
+                                           interface_info->name))
+            g_dbus_object_skeleton_remove_interface
+              (G_DBUS_OBJECT_SKELETON (object),
+               G_DBUS_INTERFACE_SKELETON (*interface_pointer));
+
           g_object_unref (*interface_pointer);
           *interface_pointer = NULL;
         }

--- a/src/storagedlogging.c
+++ b/src/storagedlogging.c
@@ -211,6 +211,7 @@ storaged_log (StoragedLogLevel     level,
   if (level >= STORAGED_LOG_LEVEL_NOTICE)
     syslog (syslog_priority, "%s", message);
   g_free (message);
+  g_free (thread_str);
 
   G_UNLOCK (log_lock);
 }


### PR DESCRIPTION
    New lsm module using LibStorageMgmt API.

    * Using LibStorageMgmt API to query external(DAS and SAN) storage RAID
      information and expose it via "org.storaged.Storaged.Drive.LSM" interface.
      The manpage included "storaged_lsm.conf(5)" include details.

    * Workflow:
        * Build in LibStorageMgmt URI:
            * sim://
                Using simulator of LibStorageMgmt, for develop only.
                Disabled by default.
            * hpsa://
                For HP SmartArray. Enabled by default. Require 'hpssacli' binary
                tool installed. The 'libstoragemgmt-hpsa-plugin' is also required.
                Check "storaged-lsm.conf(5)" manpage for detail.
        * Extra LibStorageMgmt URI can be defined in storaged-lsm.conf like:
            extra_uris = ["ontap+ssl://root@ontap.a.ip", "ontap://root@nb.ip"]
            extra_passwords = ["password_string_1", "password_string_2"]
        * Matching storaged Linux drive using udev 'ID_WWN_WITH_EXTENSION'
          against LibStorageMgmt volume VPD83 value.
        * Use LibStorageMgmt lsm_volume_raid_info(), lsm_pools(), lsm_volumes()
          methods to query disk drive RAID information.
        * Use glib main loop to refresh RAID status in given interval.

    * Add configure script option '--enable-lsm'.
    * Add DBUS API document and manpage "storaged-lsm.conf(5)".
    * Requires:
        libstoragemgmt-devel > 1.2
            # The lsm_volume_raid_info() is introduced by 1.2 release.
        libconfig-devel > 1.3.2
            # The version 1.3.2 is the shipped by RHEL6. I was referring to
            # document shipped by RHEL 6.
            # Used to read/parse storage_lsm.conf.

    * Tested hardwares(RHEL 7.1):
        * HP SmartArray
        * NetApp ONTAP

    * Using GNU Code style, enforced this command:
        indent --gnu-style --no-tabs --line-length79

The developer notes(including how to setup a develop/test environment) is in
`README_DEV_lsm.txt`

The test detail is in `TEST_NOTE_lsm.txt`.