### PR TITLE
MDRaid: Add 'Running' property.

### DIFF
--- a/data/org.storaged.Storaged.xml
+++ b/data/org.storaged.Storaged.xml
@@ -1,3 +1,4 @@
+
 <!DOCTYPE node PUBLIC
 "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
@@ -2013,6 +2014,13 @@
          see.
     -->
     <property name="ChildConfiguration" type="a(sa{sv})" access="read"/>
+
+    <!-- Running: Whether or not the array is considered running.
+
+         It is an error to call Start on a running array, and Stop on
+         a non-running array, for example.
+    -->
+    <property name="Running" type="b" access="read"/>
 
     <!--
         Start:

--- a/src/storagedlinuxmdraid.c
+++ b/src/storagedlinuxmdraid.c
@@ -341,6 +341,8 @@ storaged_linux_mdraid_update (StoragedLinuxMDRaid       *mdraid,
   storaged_mdraid_set_num_devices (iface, num_devices);
   storaged_mdraid_set_size (iface, size);
 
+  storaged_mdraid_set_running (iface, raid_device != NULL);
+
   if (g_strcmp0 (level, "raid1") == 0 ||
       g_strcmp0 (level, "raid4") == 0 ||
       g_strcmp0 (level, "raid5") == 0 ||


### PR DESCRIPTION
Looking at MDRaid.ActiveDevices or Block.MDRaid gives the same
information, but only asynchronously.

Fixes #12