### PR TITLE
lvm2: Properly monitor fstab and crypttab.

### DIFF
--- a/modules/lvm2/storagedlinuxlogicalvolume.c
+++ b/modules/lvm2/storagedlinuxlogicalvolume.c
@@ -120,7 +120,6 @@ storaged_linux_logical_volume_update (StoragedLinuxLogicalVolume     *logical_vo
                                       GVariant                       *info,
                                       gboolean                       *needs_polling_ret)
 {
-  StoragedDaemon *daemon;
   StoragedLogicalVolume *iface;
   const char *type;
   gboolean active;
@@ -207,8 +206,20 @@ storaged_linux_logical_volume_update (StoragedLinuxLogicalVolume     *logical_vo
       storaged_daemon_util_lvm2_trigger_udev (dev_file);
       logical_volume->needs_udev_hack = FALSE;
     }
+}
+
+void
+storaged_linux_logical_volume_update_etctabs (StoragedLinuxLogicalVolume     *logical_volume,
+                                              StoragedLinuxVolumeGroupObject *group_object)
+{
+  StoragedDaemon *daemon;
+  StoragedLogicalVolume *iface;
+  const gchar *uuid;
 
   daemon = storaged_linux_volume_group_object_get_daemon (group_object);
+  iface = STORAGED_LOGICAL_VOLUME (logical_volume);
+  uuid = storaged_logical_volume_get_uuid (iface);
+
   storaged_logical_volume_set_child_configuration (iface,
                                                    storaged_linux_find_child_configuration (daemon,
                                                                                             uuid));

--- a/modules/lvm2/storagedlinuxlogicalvolume.h
+++ b/modules/lvm2/storagedlinuxlogicalvolume.h
@@ -38,6 +38,8 @@ void                   storaged_linux_logical_volume_update   (StoragedLinuxLogi
                                                                StoragedLinuxVolumeGroupObject *group_object,
                                                                GVariant                       *info,
                                                                gboolean                       *needs_polling_ret);
+void                   storaged_linux_logical_volume_update_etctabs (StoragedLinuxLogicalVolume     *logical_volume,
+                                                                     StoragedLinuxVolumeGroupObject *group_object);
 
 gboolean               storaged_linux_logical_volume_teardown_block (StoragedLogicalVolume *volume,
                                                                      StoragedDaemon        *daemon,

--- a/modules/lvm2/storagedlinuxlogicalvolumeobject.c
+++ b/modules/lvm2/storagedlinuxlogicalvolumeobject.c
@@ -302,3 +302,12 @@ storaged_linux_logical_volume_object_update (StoragedLinuxLogicalVolumeObject *o
                                         info,
                                         needs_polling_ret);
 }
+
+void
+storaged_linux_logical_volume_object_update_etctabs (StoragedLinuxLogicalVolumeObject *object)
+{
+  g_return_if_fail (STORAGED_IS_LINUX_LOGICAL_VOLUME_OBJECT (object));
+
+  storaged_linux_logical_volume_update_etctabs (STORAGED_LINUX_LOGICAL_VOLUME (object->iface_logical_volume),
+                                                object->volume_group);
+}

--- a/modules/lvm2/storagedlinuxlogicalvolumeobject.h
+++ b/modules/lvm2/storagedlinuxlogicalvolumeobject.h
@@ -44,6 +44,7 @@ const gchar                      *storaged_linux_logical_volume_object_get_name 
 void                              storaged_linux_logical_volume_object_update           (StoragedLinuxLogicalVolumeObject *object,
                                                                                          GVariant                         *info,
                                                                                          gboolean                         *needs_polling_ret);
+void                              storaged_linux_logical_volume_object_update_etctabs   (StoragedLinuxLogicalVolumeObject *object);
 
 
 G_END_DECLS


### PR DESCRIPTION
Previously, we would read them only when a logical volume needed
updating because of a udev event.  Now we read them when they change.

Fixes #17