### PR TITLE
LVM2: add LVMCache support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,21 @@ fi
 AM_CONDITIONAL(HAVE_LVM2, [test "$have_lvm2" = "yes"])
 AM_CONDITIONAL(HAVE_DEVMAPPER, [test "$have_devmapper" = "yes"])
 
+# LVMCache
+have_lvmcache=no
+AC_ARG_ENABLE(lvmcache, AS_HELP_STRING([--enable-lvmcache], [enable LVMCache support]))
+if test "x$enable_lvmcache" = "xyes" \
+     -o "x$enable_modules" = "xyes" \
+     -o "x$enable_all_modules" = "xyes"; then
+
+  if test "x$have_lvm2" = "xno"; then
+    AC_MSG_ERROR([lvmcache support requested, but lvm2 module not enabled])
+  fi
+  have_lvmcache=yes
+  AC_DEFINE(HAVE_LVMCACHE, 1, [Define if lvmcache is available])
+fi
+AM_CONDITIONAL(HAVE_LVMCACHE, [test "$have_lvmcache" = "yes"])
+
 # iSCSI module
 have_iscsi=no
 have_libiscsi_session_info="no"
@@ -502,6 +517,7 @@ echo "
         Dummy module:               ${have_dummy}
         iSCSI module:               ${have_iscsi}${have_libiscsi_session_info_msg}
         LVM2  module:               ${have_lvm2}
+        LVMCache:                   ${have_lvmcache}
         Zram module:                ${have_zram}
         LibStorageMgmt module:      ${have_lsm}
 "

--- a/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
+++ b/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
@@ -523,6 +523,7 @@
     <!-- CacheAttach:
          @cache_name: The name of an existing volume.
          @options: Additional options.
+         @since: 2.3.0
 
          Creates cache LV. Logical volume which name is provided, will be formated, converted to cache type
          and attached to origin logical volume as a cache pool LV. Logical volumes must be in the same volume group.
@@ -536,6 +537,7 @@
 
     <!-- CacheSplit:
          @options: Additional options.
+         @since: 2.3.0
 
          Splits Cache LV to Cache pool LV and Origin LV, not afeecting its content.
 

--- a/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
+++ b/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
@@ -520,6 +520,31 @@
       <arg name="result" type="o" direction="out"/>
     </method>
 
+    <!-- CacheAttach:
+         @cache_name: The name of an existing volume.
+         @options: Additional options.
+
+         Creates cache LV. Logical volume which name is provided, will be formated, converted to cache type
+         and attached to origin logical volume as a cache pool LV. Logical volumes must be in the same volume group.
+
+         No additional options are currently defined.
+    -->
+    <method name="CacheAttach">
+      <arg name="cache_name" type="s" direction="in"/>
+      <arg name="options" type= "a{sv}" direction="in"/>
+    </method>
+
+    <!-- CacheSplit:
+         @options: Additional options.
+
+         Splits Cache LV to Cache pool LV and Origin LV, not afeecting its content.
+
+         No additional options are currently defined.
+    -->
+    <method name="CacheSplit">
+      <arg name="options" type= "a{sv}" direction="in"/>
+    </method>
+
   </interface>
 
   <!-- ********************************************************************** -->

--- a/modules/lvm2/storagedlinuxlogicalvolume.c
+++ b/modules/lvm2/storagedlinuxlogicalvolume.c
@@ -357,7 +357,6 @@ handle_delete (StoragedLogicalVolume *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -392,10 +391,9 @@ handle_delete (StoragedLogicalVolume *_volume,
     }
 
   message = N_("Authentication is required to delete a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -497,7 +495,6 @@ handle_rename (StoragedLogicalVolume   *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -531,10 +528,9 @@ handle_rename (StoragedLogicalVolume   *_volume,
     }
 
   message = N_("Authentication is required to rename a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -600,7 +596,6 @@ handle_resize (StoragedLogicalVolume *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -634,10 +629,9 @@ handle_resize (StoragedLogicalVolume *_volume,
     }
 
   message = N_("Authentication is required to rename a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -735,7 +729,6 @@ handle_activate (StoragedLogicalVolume *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -768,10 +761,9 @@ handle_activate (StoragedLogicalVolume *_volume,
     }
 
   message = N_("Authentication is required to activate a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -840,7 +832,6 @@ handle_deactivate (StoragedLogicalVolume *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -872,10 +863,9 @@ handle_deactivate (StoragedLogicalVolume *_volume,
     }
 
   message = N_("Authentication is required to deactivate a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -929,7 +919,6 @@ handle_create_snapshot (StoragedLogicalVolume *_volume,
   StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (_volume);
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -964,10 +953,9 @@ handle_create_snapshot (StoragedLogicalVolume *_volume,
     }
 
   message = N_("Authentication is required to create a snapshot of a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))

--- a/modules/lvm2/storagedlinuxlogicalvolume.c
+++ b/modules/lvm2/storagedlinuxlogicalvolume.c
@@ -1038,12 +1038,10 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
 {
 #ifndef HAVE_LVMCACHE
 
-  GError *error;
-  g_set_error (&error,
-               STORAGED_ERROR,
-               STORAGED_ERROR_FAILED,
-               "LVMCache not enabled at compile time.");
-  g_dbus_method_invocation_take_error (invocation,error);
+  g_dbus_method_invocation_return_error (invocation,
+                                         STORAGED_ERROR,
+                                         STORAGED_ERROR_FAILED,
+                                         N_("LVMCache not enabled at compile time."));
   return TRUE;
 
 #else
@@ -1053,7 +1051,6 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   StoragedLinuxVolumeGroupObject *group_object;
   GString *cmd;
   gchar *escaped_group_name = NULL;
@@ -1067,27 +1064,27 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
       goto out;
     }
 
+
   daemon = storaged_linux_logical_volume_object_get_daemon (object);
 
   if (!storaged_daemon_util_get_caller_uid_sync (daemon,
                                                  invocation,
-                                                 NULL,
+                                                 NULL /* GCancellable */,
                                                  &caller_uid,
-                                                 &caller_gid,
+                                                 NULL,
                                                  NULL,
                                                  &error))
-  {
-    g_dbus_method_invocation_take_error (invocation, error);
-    goto out;
-  }
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
 
-  if (!storaged_daemon_util_check_authorization_sync (daemon,
-                                                      STORAGED_OBJECT (object),
-                                                      "org.storaged.Storaged.lvm2.manage-lvm",
-                                                      options,
-                                                      "Authentication is required to convert logica volume to cache",
-                                                      invocation))
-    goto out;
+  STORAGED_DAEMON_CHECK_AUTHORIZATION (daemon,
+                                       STORAGED_OBJECT (object),
+                                       lvm2_policy_action_id,
+                                       options,
+                                       N_("Authentication is required to convert logica volume to cache"),
+                                       invocation);
 
   group_object = storaged_linux_logical_volume_object_get_volume_group (object);
 
@@ -1117,7 +1114,7 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
       g_dbus_method_invocation_return_error (invocation,
                                              STORAGED_ERROR,
                                              STORAGED_ERROR_FAILED,
-                                             "Error converting volume: %s",
+                                             N_("Error converting volume: %s"),
                                              error_message);
       goto out;
     }
@@ -1144,13 +1141,10 @@ handle_cache_split (StoragedLogicalVolume  *volume_,
 {
 #ifndef HAVE_LVMCACHE
 
-  GError *error;
-  g_set_error (&error,
-               STORAGED_ERROR,
-               STORAGED_ERROR_FAILED,
-               "LVMCache not enabled at compile time.");
-  g_dbus_method_invocation_take_error (invocation,error);
-
+  g_dbus_method_invocation_return_error (invocation,
+                                         STORAGED_ERROR,
+                                         STORAGED_ERROR_FAILED,
+                                         N_("LVMCache not enabled at compile time."));
   return TRUE;
 
 #else
@@ -1160,7 +1154,6 @@ handle_cache_split (StoragedLogicalVolume  *volume_,
   StoragedLinuxLogicalVolumeObject *object = NULL;
   StoragedDaemon *daemon;
   uid_t caller_uid;
-  gid_t caller_gid;
   StoragedLinuxVolumeGroupObject *group_object;
   GString *cmd;
   gchar *escaped_group_name = NULL;
@@ -1178,23 +1171,22 @@ handle_cache_split (StoragedLogicalVolume  *volume_,
 
   if (!storaged_daemon_util_get_caller_uid_sync (daemon,
                                                  invocation,
-                                                 NULL,
+                                                 NULL /* GCancellable */,
                                                  &caller_uid,
-                                                 &caller_gid,
+                                                 NULL,
                                                  NULL,
                                                  &error))
-  {
-    g_dbus_method_invocation_take_error (invocation, error);
-    goto out;
-  }
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
 
-  if (!storaged_daemon_util_check_authorization_sync (daemon,
-                                                      STORAGED_OBJECT (object),
-                                                      "org.storaged.Storaged.lvm2.manage-lvm",
-                                                      options,
-                                                      "Authentication is required to split cache pool LV off of a cache LV",
-                                                      invocation))
-    goto out;
+  STORAGED_DAEMON_CHECK_AUTHORIZATION (daemon,
+                                       STORAGED_OBJECT (object),
+                                       lvm2_policy_action_id,
+                                       options,
+                                       N_("Authentication is required to split cache pool LV off of a cache LV"),
+                                       invocation);
 
   group_object = storaged_linux_logical_volume_object_get_volume_group (object);
 
@@ -1221,7 +1213,7 @@ handle_cache_split (StoragedLogicalVolume  *volume_,
       g_dbus_method_invocation_return_error (invocation,
                                              STORAGED_ERROR,
                                              STORAGED_ERROR_FAILED,
-                                             "Error converting volume: %s",
+                                             N_("Error converting volume: %s"),
                                              error_message);
       goto out;
     }

--- a/modules/lvm2/storagedlinuxlogicalvolume.c
+++ b/modules/lvm2/storagedlinuxlogicalvolume.c
@@ -1030,6 +1030,216 @@ handle_create_snapshot (StoragedLogicalVolume *_volume,
   return TRUE;
 }
 
+static gboolean
+handle_cache_attach (StoragedLogicalVolume  *volume_,
+                     GDBusMethodInvocation  *invocation,
+                     const gchar            *cache_name,
+                     GVariant               *options)
+{
+#ifndef HAVE_LVMCACHE
+
+  GError *error;
+  g_set_error (&error,
+               STORAGED_ERROR,
+               STORAGED_ERROR_FAILED,
+               "LVMCache not enabled at compile time.");
+  g_dbus_method_invocation_take_error (invocation,error);
+  return TRUE;
+
+#else
+
+  GError *error = NULL;
+  StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (volume_);
+  StoragedLinuxLogicalVolumeObject *object = NULL;
+  StoragedDaemon *daemon;
+  uid_t caller_uid;
+  gid_t caller_gid;
+  StoragedLinuxVolumeGroupObject *group_object;
+  GString *cmd;
+  gchar *escaped_group_name = NULL;
+  gchar *escaped_origin_name = NULL;
+  gchar *error_message;
+
+  object = storaged_daemon_util_dup_object (volume, &error);
+  if (object == NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
+
+  daemon = storaged_linux_logical_volume_object_get_daemon (object);
+
+  if (!storaged_daemon_util_get_caller_uid_sync (daemon,
+                                                 invocation,
+                                                 NULL,
+                                                 &caller_uid,
+                                                 &caller_gid,
+                                                 NULL,
+                                                 &error))
+  {
+    g_dbus_method_invocation_take_error (invocation, error);
+    goto out;
+  }
+
+  if (!storaged_daemon_util_check_authorization_sync (daemon,
+                                                      STORAGED_OBJECT (object),
+                                                      "org.storaged.Storaged.lvm2.manage-lvm",
+                                                      options,
+                                                      "Authentication is required to convert logica volume to cache",
+                                                      invocation))
+    goto out;
+
+  group_object = storaged_linux_logical_volume_object_get_volume_group (object);
+
+  escaped_group_name = storaged_daemon_util_escape_and_quote (storaged_linux_volume_group_object_get_name (group_object));
+  escaped_origin_name = storaged_daemon_util_escape_and_quote (storaged_linux_logical_volume_object_get_name (object));
+  cache_name = storaged_daemon_util_escape_and_quote (cache_name);
+
+  cmd = g_string_new ("");
+  g_string_append_printf (cmd,
+                          "lvconvert --type cache --cachepool %s/%s %s/%s -y",
+                          escaped_group_name,
+                          cache_name,
+                          escaped_group_name,
+                          escaped_origin_name);
+
+  if (!storaged_daemon_launch_spawned_job_sync (daemon,
+                                                STORAGED_OBJECT (object),
+                                                "lvm-lv-make-cache", caller_uid,
+                                                NULL,
+                                                0,
+                                                0,
+                                                NULL,
+                                                &error_message,
+                                                NULL,
+                                                "%s", cmd->str))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             STORAGED_ERROR,
+                                             STORAGED_ERROR_FAILED,
+                                             "Error converting volume: %s",
+                                             error_message);
+      goto out;
+    }
+
+  storaged_logical_volume_complete_cache_attach (volume_, invocation);
+out:
+  g_free (error_message);
+  g_free (escaped_group_name);
+  g_free (escaped_origin_name);
+  if (cmd)
+    g_string_free (cmd, TRUE);
+  g_clear_object (&object);
+
+return TRUE;
+
+#endif /* HAVE_LVMCACHE */
+}
+
+
+static gboolean
+handle_cache_split (StoragedLogicalVolume  *volume_,
+                    GDBusMethodInvocation  *invocation,
+                    GVariant               *options)
+{
+#ifndef HAVE_LVMCACHE
+
+  GError *error;
+  g_set_error (&error,
+               STORAGED_ERROR,
+               STORAGED_ERROR_FAILED,
+               "LVMCache not enabled at compile time.");
+  g_dbus_method_invocation_take_error (invocation,error);
+
+  return TRUE;
+
+#else
+
+  GError *error = NULL;
+  StoragedLinuxLogicalVolume *volume = STORAGED_LINUX_LOGICAL_VOLUME (volume_);
+  StoragedLinuxLogicalVolumeObject *object = NULL;
+  StoragedDaemon *daemon;
+  uid_t caller_uid;
+  gid_t caller_gid;
+  StoragedLinuxVolumeGroupObject *group_object;
+  GString *cmd;
+  gchar *escaped_group_name = NULL;
+  gchar *escaped_origin_name = NULL;
+  gchar *error_message;
+
+  object = storaged_daemon_util_dup_object (volume, &error);
+  if (object == NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
+
+  daemon = storaged_linux_logical_volume_object_get_daemon (object);
+
+  if (!storaged_daemon_util_get_caller_uid_sync (daemon,
+                                                 invocation,
+                                                 NULL,
+                                                 &caller_uid,
+                                                 &caller_gid,
+                                                 NULL,
+                                                 &error))
+  {
+    g_dbus_method_invocation_take_error (invocation, error);
+    goto out;
+  }
+
+  if (!storaged_daemon_util_check_authorization_sync (daemon,
+                                                      STORAGED_OBJECT (object),
+                                                      "org.storaged.Storaged.lvm2.manage-lvm",
+                                                      options,
+                                                      "Authentication is required to split cache pool LV off of a cache LV",
+                                                      invocation))
+    goto out;
+
+  group_object = storaged_linux_logical_volume_object_get_volume_group (object);
+
+  escaped_group_name = storaged_daemon_util_escape_and_quote (storaged_linux_volume_group_object_get_name (group_object));
+  escaped_origin_name = storaged_daemon_util_escape_and_quote (storaged_linux_logical_volume_object_get_name (object));
+
+  cmd = g_string_new ("");
+  g_string_append_printf (cmd,
+                          "lvconvert --splitcache %s/%s -y",
+                          escaped_group_name,
+                          escaped_origin_name);
+
+  if (!storaged_daemon_launch_spawned_job_sync (daemon,
+                                                STORAGED_OBJECT (object),
+                                                "lvm-lv-split-cache", caller_uid,
+                                                NULL,
+                                                0,
+                                                0,
+                                                NULL,
+                                                &error_message,
+                                                NULL,
+                                                "%s", cmd->str))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             STORAGED_ERROR,
+                                             STORAGED_ERROR_FAILED,
+                                             "Error converting volume: %s",
+                                             error_message);
+      goto out;
+    }
+
+  storaged_logical_volume_complete_cache_split (volume_, invocation);
+out:
+  g_free (error_message);
+  g_free (escaped_group_name);
+  g_free (escaped_origin_name);
+  if (cmd)
+    g_string_free (cmd, TRUE);
+  g_clear_object (&object);
+
+  return TRUE;
+
+#endif /* HAVE_LVMCACHE */
+}
+
 /* ---------------------------------------------------------------------------------------------------- */
 
 static void
@@ -1041,4 +1251,7 @@ logical_volume_iface_init (StoragedLogicalVolumeIface *iface)
   iface->handle_activate = handle_activate;
   iface->handle_deactivate = handle_deactivate;
   iface->handle_create_snapshot = handle_create_snapshot;
+
+  iface->handle_cache_attach = handle_cache_attach;
+  iface->handle_cache_split = handle_cache_split;
 }

--- a/modules/lvm2/storagedlinuxlogicalvolume.c
+++ b/modules/lvm2/storagedlinuxlogicalvolume.c
@@ -1043,6 +1043,7 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
   GString *cmd;
   gchar *escaped_group_name = NULL;
   gchar *escaped_origin_name = NULL;
+  gchar *escaped_cache_name = NULL;
   gchar *error_message;
 
   object = storaged_daemon_util_dup_object (volume, &error);
@@ -1078,13 +1079,13 @@ handle_cache_attach (StoragedLogicalVolume  *volume_,
 
   escaped_group_name = storaged_daemon_util_escape_and_quote (storaged_linux_volume_group_object_get_name (group_object));
   escaped_origin_name = storaged_daemon_util_escape_and_quote (storaged_linux_logical_volume_object_get_name (object));
-  cache_name = storaged_daemon_util_escape_and_quote (cache_name);
+  escaped_cache_name = storaged_daemon_util_escape_and_quote (cache_name);
 
   cmd = g_string_new ("");
   g_string_append_printf (cmd,
                           "lvconvert --type cache --cachepool %s/%s %s/%s -y",
                           escaped_group_name,
-                          cache_name,
+                          escaped_cache_name,
                           escaped_group_name,
                           escaped_origin_name);
 
@@ -1112,6 +1113,7 @@ out:
   g_free (error_message);
   g_free (escaped_group_name);
   g_free (escaped_origin_name);
+  g_free (escaped_cache_name);
   if (cmd)
     g_string_free (cmd, TRUE);
   g_clear_object (&object);

--- a/modules/lvm2/storagedlinuxmanagerlvm2.c
+++ b/modules/lvm2/storagedlinuxmanagerlvm2.c
@@ -210,7 +210,6 @@ handle_volume_group_create (StoragedManagerLVM2     *_object,
   uid_t caller_uid;
   GError *error = NULL;
   const gchar *message;
-  const gchar *action_id;
   GList *blocks = NULL;
   GList *l;
   guint n;
@@ -229,10 +228,9 @@ handle_volume_group_create (StoragedManagerLVM2     *_object,
     }
 
   message = N_("Authentication is required to create a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (manager->daemon,
                                                       NULL,
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       arg_options,
                                                       message,
                                                       invocation))

--- a/modules/lvm2/storagedlinuxvolumegroup.c
+++ b/modules/lvm2/storagedlinuxvolumegroup.c
@@ -254,7 +254,6 @@ handle_delete (StoragedVolumeGroup   *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedLinuxVolumeGroupObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -305,10 +304,9 @@ handle_delete (StoragedVolumeGroup   *_group,
     }
 
   message = N_("Authentication is required to delete a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       arg_options,
                                                       message,
                                                       invocation))
@@ -384,7 +382,6 @@ handle_rename (StoragedVolumeGroup   *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedLinuxVolumeGroupObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -416,10 +413,9 @@ handle_rename (StoragedVolumeGroup   *_group,
     }
 
   message = N_("Authentication is required to rename a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -487,7 +483,6 @@ handle_add_device (StoragedVolumeGroup      *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedDaemon *daemon;
   StoragedLinuxVolumeGroupObject *object;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -539,10 +534,9 @@ handle_add_device (StoragedVolumeGroup      *_group,
     }
 
   message = N_("Authentication is required to add a device to a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -610,7 +604,6 @@ handle_remove_device (StoragedVolumeGroup      *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedDaemon *daemon;
   StoragedLinuxVolumeGroupObject *object;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -662,10 +655,9 @@ handle_remove_device (StoragedVolumeGroup      *_group,
     }
 
   message = N_("Authentication is required to remove a device from a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -745,7 +737,6 @@ handle_empty_device (StoragedVolumeGroup      *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedDaemon *daemon;
   StoragedLinuxVolumeGroupObject *object;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -796,10 +787,9 @@ handle_empty_device (StoragedVolumeGroup      *_group,
     }
 
   message = N_("Authentication is required to empty a device in a volume group");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -893,7 +883,6 @@ handle_create_plain_volume (StoragedVolumeGroup   *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedLinuxVolumeGroupObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -926,10 +915,9 @@ handle_create_plain_volume (StoragedVolumeGroup   *_group,
     }
 
   message = N_("Authentication is required to create a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -996,7 +984,6 @@ handle_create_thin_pool_volume (StoragedVolumeGroup   *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedLinuxVolumeGroupObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -1029,10 +1016,9 @@ handle_create_thin_pool_volume (StoragedVolumeGroup   *_group,
     }
 
   message = N_("Authentication is required to create a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))
@@ -1100,7 +1086,6 @@ handle_create_thin_volume (StoragedVolumeGroup   *_group,
   StoragedLinuxVolumeGroup *group = STORAGED_LINUX_VOLUME_GROUP (_group);
   StoragedLinuxVolumeGroupObject *object = NULL;
   StoragedDaemon *daemon;
-  const gchar *action_id;
   const gchar *message;
   uid_t caller_uid;
   gid_t caller_gid;
@@ -1135,10 +1120,9 @@ handle_create_thin_volume (StoragedVolumeGroup   *_group,
     }
 
   message = N_("Authentication is required to create a logical volume");
-  action_id = "org.storaged.Storaged.lvm2.manage-lvm";
   if (!storaged_daemon_util_check_authorization_sync (daemon,
                                                       STORAGED_OBJECT (object),
-                                                      action_id,
+                                                      lvm2_policy_action_id,
                                                       options,
                                                       message,
                                                       invocation))

--- a/modules/lvm2/storagedlvm2daemonutil.c
+++ b/modules/lvm2/storagedlvm2daemonutil.c
@@ -59,6 +59,8 @@
  * Various utility routines.
  */
 
+const gchar  *lvm2_policy_action_id = "org.storaged.Storaged.lvm2.manage-lvm";
+
 gboolean
 storaged_daemon_util_lvm2_block_is_unused (StoragedBlock *block,
                                            GError       **error)

--- a/modules/lvm2/storagedlvm2daemonutil.h
+++ b/modules/lvm2/storagedlvm2daemonutil.h
@@ -26,6 +26,8 @@
 
 G_BEGIN_DECLS
 
+extern const gchar  *lvm2_policy_action_id;
+
 gboolean storaged_daemon_util_lvm2_block_is_unused (StoragedBlock  *block,
                                                     GError        **error);
 


### PR DESCRIPTION
LVM cache uses LVM2 tools to create cache LV, logical volume type which consists of small and fast LV (Cache Pool LV) and a large and slow LV (Origin LV). Performance of Origin LV is improved by storing the frequently used blocks on Cache Pool LV.