### PR TITLE
ZRAM: add configuration for setup after reboot

### DIFF
--- a/data/80-storaged.rules
+++ b/data/80-storaged.rules
@@ -150,3 +150,6 @@ KERNEL=="sr*", ENV{ID_VENDOR}=="SanDisk", ENV{ID_MODEL}=="Cruzer", ENV{ID_FS_LAB
 # See http://mjg59.dreamwidth.org/11285.html for more details
 #
 ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0", ENV{ID_PART_ENTRY_NUMBER}=="1", ENV{ID_FS_TYPE}=="iso9660|udf", ENV{STORAGED_IGNORE}="0"
+
+# Zram devices setup
+KERNEL=="zram[0-9]", ENV{SYSTEMD_WANTS}="zram-setup@zram%n.service", TAG+="systemd

--- a/modules/zram/Makefile.am
+++ b/modules/zram/Makefile.am
@@ -6,6 +6,12 @@ ZRAM_MODULE_DIR = $(top_srcdir)/modules/zram
 
 MODULE_SO = libstoraged_zram.so
 
+zramconfdir = $(libdir)/zram.conf.d
+zramconf_DATA =
+
+modprobedir = $(libdir)/modprobe.d
+modloaddir = $(libdir)/modules-load.d
+
 NULL =
 
 CPPFLAGS =                                                                     \
@@ -17,6 +23,9 @@ CPPFLAGS =                                                                     \
 	-DPACKAGE_LOCALSTATE_DIR=\""$(localstatedir)"\"                        \
 	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\"                                \
 	-DPACKAGE_LIB_DIR=\""$(libdir)"\"                                      \
+        -DPACKAGE_ZRAMCONF_DIR=\""$(zramconfdir)"\"                            \
+        -DPACKAGE_MODPROBE_DIR=\""$(modprobedir)"\"                            \
+        -DPACKAGE_MODLOAD_DIR=\""$(modloaddir)"\"                              \
 	-DLVM_HELPER_DIR=\""$(prefix)/lib/storaged/"\"                         \
 	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT                                \
 	-DSTORAGED_COMPILATION                                                 \

--- a/modules/zram/data/Makefile.am
+++ b/modules/zram/data/Makefile.am
@@ -5,10 +5,13 @@ polkitdir       = $(datadir)/polkit-1/actions
 polkit_in_files = org.storaged.Storaged.zram.policy.in
 polkit_DATA     = $(polkit_in_files:.policy.in=.policy)
 
+systemdsystemunit_DATA = zram-setup@.service
+
 @INTLTOOL_POLICY_RULE@
 
 EXTRA_DIST =                                                    \
 	org.storaged.Storaged.zram.xml                          \
+        zram-setup@.service                                     \
 	$(polkit_in_files)                                      \
 	$(NULL)
 

--- a/modules/zram/data/zram-setup@.service
+++ b/modules/zram/data/zram-setup@.service
@@ -1,0 +1,14 @@
+ervice initializes zram devices
+[Unit]
+Description=Setup zram based device %i
+After=dev-%i.device
+Requires=dev-%i.device
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/usr/local/lib/zram.conf.d/%i-env
+ExecStart=-/bin/sh -c 'echo $ZRAM_NUM_STR > /sys/class/block/%i/max_comp_streams'
+ExecStart=-/bin/sh -c 'echo $ZRAM_DEV_SIZE > /sys/class/block/%i/disksize'
+ExecStart=-/bin/sh -c '[ "$SWAP" = "y" ] && mkswap /dev/%i && swapon /dev/%i'
+ExecStop=-/bin/sh -c 'echo 1 > /sys/class/block/%i/reset'

--- a/modules/zram/data/zram-setup@.service
+++ b/modules/zram/data/zram-setup@.service
@@ -1,4 +1,4 @@
-ervice initializes zram devices
+#Service initializes zram devices
 [Unit]
 Description=Setup zram based device %i
 After=dev-%i.device

--- a/modules/zram/storagedlinuxblockzram.c
+++ b/modules/zram/storagedlinuxblockzram.c
@@ -235,6 +235,7 @@ zram_device_activate (StoragedBlockZRAM      *zramblock_,
   StoragedLinuxBlockZRAM *zramblock = STORAGED_LINUX_BLOCK_ZRAM (zramblock_);
   StoragedLinuxBlockObject *object = NULL;
   gchar *dev_file = NULL;
+  gchar *filename = NULL;
   gchar *label;
   GError *error = NULL;
 
@@ -269,11 +270,19 @@ zram_device_activate (StoragedBlockZRAM      *zramblock_,
     goto out;
   }
 
+  filename = g_strdup_printf("%s/%s-env", PACKAGE_ZRAMCONF_DIR, (strrchr(dev_file,'/')+1));
+  if (! set_conf_property (filename, "SWAP", "y", &error))
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
+
   storaged_block_zram_set_active (zramblock_, TRUE);
   storaged_block_zram_complete_activate(zramblock_,invocation);
 
 out:
   g_clear_object (&object);
+  g_free (filename);
   g_free (dev_file);
   g_free (label);
   return TRUE;
@@ -329,6 +338,7 @@ handle_deactivate (StoragedBlockZRAM      *zramblock_,
   StoragedLinuxBlockZRAM *zramblock = STORAGED_LINUX_BLOCK_ZRAM (zramblock_);
   StoragedLinuxBlockObject *object = NULL;
   gchar *dev_file = NULL;
+  gchar *filename = NULL;
   GError *error = NULL;
 
   object = storaged_daemon_util_dup_object (zramblock, &error);
@@ -359,11 +369,18 @@ handle_deactivate (StoragedBlockZRAM      *zramblock_,
     goto out;
   }
 
+  if (! set_conf_property (filename, "SWAP", "n", &error))
+    {
+      g_dbus_method_invocation_take_error (invocation, error);
+      goto out;
+    }
+
   storaged_block_zram_set_active (zramblock_, FALSE);
   storaged_block_zram_complete_deactivate(zramblock_,invocation);
 
 out:
   g_clear_object (&object);
+  g_free (filename);
   g_free (dev_file);
 
   return TRUE;

--- a/modules/zram/storagedlinuxblockzram.c
+++ b/modules/zram/storagedlinuxblockzram.c
@@ -270,7 +270,7 @@ zram_device_activate (StoragedBlockZRAM      *zramblock_,
     goto out;
   }
 
-  filename = g_strdup_printf("%s/%s-env", PACKAGE_ZRAMCONF_DIR, (strrchr(dev_file,'/')+1));
+  filename = g_build_filename(PACKAGE_ZRAMCONF_DIR, g_path_get_basename(dev_file), NULL);
   if (! set_conf_property (filename, "SWAP", "y", &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
@@ -369,6 +369,7 @@ handle_deactivate (StoragedBlockZRAM      *zramblock_,
     goto out;
   }
 
+  filename = g_build_filename(PACKAGE_ZRAMCONF_DIR, g_path_get_basename(dev_file), NULL);
   if (! set_conf_property (filename, "SWAP", "n", &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);

--- a/modules/zram/storagedlinuxmanagerzram.c
+++ b/modules/zram/storagedlinuxmanagerzram.c
@@ -258,6 +258,7 @@ delete_conf_files (GError **error)
   gboolean rval = TRUE;
   GDir *zramconfd;
   gchar *filename = NULL;
+  const gchar *name;
 
   filename = g_build_filename (PACKAGE_MODLOAD_DIR, "/zram.conf", NULL);
 
@@ -284,13 +285,13 @@ delete_conf_files (GError **error)
     rval = FALSE;
     goto out;
   }
-  do
+
+  while (name = g_dir_read_name (zramconfd))
   {
     g_free (filename);
-    filename = g_build_filename(PACKAGE_ZRAMCONF_DIR,
-                                g_dir_read_name (zramconfd),
-                                NULL);
-  } while (! g_unlink (filename));
+    filename = g_build_filename (PACKAGE_ZRAMCONF_DIR, name, NULL);
+    g_unlink (filename);
+  }
   g_dir_close (zramconfd);
 
 out:

--- a/modules/zram/storagedzramutil.c
+++ b/modules/zram/storagedzramutil.c
@@ -17,6 +17,69 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <gio/gio.h>
+
 #include "storagedzramutil.h"
 
 const gchar *zram_policy_action_id = "org.storaged.Storaged.zram.manage-zram";
+
+set_conf_property (char *filename,
+                   const char *key,
+                   const char *value,
+                   GError **error)
+{
+  FILE *f = NULL;
+  FILE  *tmp = NULL;
+  char buff[256];
+  gchar* tmpfname;
+  gboolean newprop = TRUE;
+
+  f = fopen (filename, "r+");
+  if (f == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),"%m");
+      return FALSE;
+    }
+
+  tmpfname = g_strdup_printf ("%sXXXXXX", filename);
+  mkstemp (tmpfname);
+  chmod (tmpfname, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  tmp = fopen (tmpfname, "w");
+
+  if (tmp == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),"%m");
+      fclose (f);
+      g_free (tmpfname);
+      return FALSE;
+    }
+
+  while (fgets (buff, 255, f))
+    {
+      if (! strncmp(key, buff, strlen(key)))
+        {
+          strncpy (buff+strlen (key)+1, value, 255-strlen (key));
+          buff[strlen (buff)] = '\n';
+          newprop = FALSE;
+        }
+      fputs (buff, tmp);
+    }
+
+  if (newprop)
+    fprintf (tmp,"%s=%s\n", key, value);
+  fclose (f);
+  fclose (tmp);
+
+  if (rename (tmpfname, filename))
+  {
+    g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),"%m");
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/modules/zram/storagedzramutil.h
+++ b/modules/zram/storagedzramutil.h
@@ -24,4 +24,6 @@
 
 extern const gchar  *zram_policy_action_id;
 
+gboolean set_conf_property (char *filename, const char *key, const char *value, GError **error);
+
 #endif /* __STORAGED_ZRAM_UTIL_H__ */


### PR DESCRIPTION
Adding/removing of zram devices sets files which are responsible for following process:
After reboot there is zram kernel module loaded with number of devices stated in modprobe. Device adding will evoke service run, which sets disksizes and number of compresson streams and optionally makes swaps from zram devices.