### PR TITLE
lvm2: Use "NNN%FREE" syntax when creating thin pools

### DIFF
--- a/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
+++ b/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
@@ -270,12 +270,16 @@
 
     <!-- CreateThinPoolVolume:
          @name: The name of the new logical volume.
-         @size: The size.
+         @size: The total size.
          @options: Additional options.
          @result: The object path of the new logical volume.
 
          Create a new logical volume that can be used to back
-         thinly-provisioned logical volumes.
+         thinly-provisioned logical volumes.  The @size parameter is
+         the total amount of space taken out of the volume group.
+         That space will be used for data and metadata.  The actual
+         amount of data that can be stored in the pool will be
+         slightly smaller.
 
          No additional options are currently defined.
     -->

--- a/modules/lvm2/storagedlinuxvolumegroup.c
+++ b/modules/lvm2/storagedlinuxvolumegroup.c
@@ -977,6 +977,7 @@ handle_create_thin_pool_volume (StoragedVolumeGroup   *_group,
   gid_t caller_gid;
   gchar *escaped_volume_name = NULL;
   gchar *escaped_group_name = NULL;
+  int size_percentage;
   GString *cmd = NULL;
   gchar *error_message = NULL;
   const gchar *lv_objpath;
@@ -1015,9 +1016,25 @@ handle_create_thin_pool_volume (StoragedVolumeGroup   *_group,
   escaped_group_name = storaged_daemon_util_escape_and_quote (storaged_linux_volume_group_object_get_name (object));
   arg_size -= arg_size % 512;
 
+  /* HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1314770
+   *
+   * We want to say "take this amount of space and turn it into a thin
+   * pool with all your defaults" but ordinarily lvcreate understands
+   * the "-l" option as "make me a thin pool for this much data and
+   * use as much extra space as is needed according to your defaults".
+   *
+   * But when using the "NNN%FREE" syntax with the "-l" option
+   * lvcreate will do what we want.
+   *
+   * Unfortunately, the "NNN%FREE" syntax only allows integers, so the
+   * resolution is limited.
+   */
+
+  size_percentage = arg_size * 100 / storaged_volume_group_get_free_size (_group);
+
   cmd = g_string_new ("");
-  g_string_append_printf (cmd, "lvcreate %s -T -L %" G_GUINT64_FORMAT "b --thinpool %s",
-                          escaped_group_name, arg_size, escaped_volume_name);
+  g_string_append_printf (cmd, "lvcreate %s -T -l %d%%FREE --thinpool %s",
+                          escaped_group_name, size_percentage, escaped_volume_name);
 
   if (!storaged_daemon_launch_spawned_job_sync (daemon,
                                                 STORAGED_OBJECT (object),


### PR DESCRIPTION
So that the 'size' argument to the CreateThinPoolVolume really
specifies the total amount of space taken out of the volume group, as
intended.