### PR TITLE
LVM2: Include metadata size in Size property.

### DIFF
--- a/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
+++ b/modules/lvm2/data/org.storaged.Storaged.lvm2.xml
@@ -357,7 +357,8 @@
 
     <!-- Size:
 
-         The size of this logical volume in bytes.
+         The total size of this logical volume in bytes, including the
+         size of the metadata.
     -->
     <property name="Size" type="t" access="read"/>
 

--- a/modules/lvm2/storagedlvmhelper.c
+++ b/modules/lvm2/storagedlvmhelper.c
@@ -137,6 +137,7 @@ show_logical_volume (vg_t vg,
   add_lvprop (&result, "data_percent", lv);
   add_lvprop (&result, "metadata_percent", lv);
   add_lvprop (&result, "copy_percent", lv);
+  add_lvprop (&result, "lv_metadata_size", lv);
 
   return g_variant_builder_end (&result);
 }


### PR DESCRIPTION
To match how CreateThinPool interprets the size.