### PR TITLE
Core: Don't complete partition/format methods twice

### DIFF
--- a/src/storagedlinuxpartitiontable.c
+++ b/src/storagedlinuxpartitiontable.c
@@ -707,10 +707,6 @@ partition_table_created:
   if (was_partitioned)
     storaged_linux_block_object_reread_partition_table (STORAGED_LINUX_BLOCK_OBJECT (object));
 
-  storaged_partition_table_complete_create_partition (table,
-                                                      invocation,
-                                                      g_dbus_object_get_object_path (G_DBUS_OBJECT (partition_object)));
-
  out:
   g_free (escaped_partition_device);
   g_free (wait_data);


### PR DESCRIPTION
This bug was introduced when porting 5c859c from udisks2 as eb4b99.
In storaged, the method is not completed in the utility function
storaged_linux_partition_table_handle_create_partition, but in the
actual method handlers handle_create_partition and
handle_create_partition_and_format.

Completing the method invocation twice causes the client to miss any
later error messages.