### PR TITLE
Packaging: Add 'rpm' make target; build the spec file by autoconf

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import time
+import subprocess
+import argparse
+import unittest
+import storagedtestcase
+import glob
+
+
+VDEV_SIZE = 300000000  # size of virtual test device
+
+
+def find_daemon(projdir):
+    if os.path.exists(os.path.join(projdir, 'src', 'storaged')):
+        daemon_bin = 'storaged'
+    elif os.path.exists(os.path.join(projdir, 'src', 'udisksd')):
+        daemon_bin = 'udisksd'
+    else:
+        print("Cannot find the daemon binary", file=sys.stderr)
+        sys.exit(1)
+    return daemon_bin
+
+
+def setup_vdevs():
+    '''create virtual test devices'''
+
+    # craete 4 fake SCSI hard drives
+    assert subprocess.call(['modprobe', 'scsi_debug', 'dev_size_mb=%i' % (
+        VDEV_SIZE / 1048576), 'num_tgts=4']) == 0, 'Failure to modprobe scsi_debug'
+
+    # wait until the drives got created
+    dirs = []
+    while len(dirs) < 4:
+        dirs = glob.glob('/sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block')
+        time.sleep(0.1)
+    assert len(dirs) == 4
+
+    vdevs = []
+    for d in dirs:
+        devs = os.listdir(d)
+        assert len(devs) == 1
+        vdevs.append('/dev/' + devs[0])
+        assert os.path.exists(vdevs[-1])
+
+    # let's be 100% sure that we pick a virtual one
+    for d in vdevs:
+        assert open('/sys/block/%s/device/model' %
+                    os.path.basename(d)).read().strip() == 'scsi_debug'
+
+    storagedtestcase.test_devs = vdevs
+
+
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    daemon_log = sys.stdout
+
+    argparser = argparse.ArgumentParser(description='storaged D-Bus test suite')
+    argparser.add_argument('-l', '--log-file', dest='logfile',
+                           help='write daemon log to a file')
+    argparser.add_argument('testname', nargs='*',
+                           help='name of test class or method (e. g. "Drive", "FS.test_ext2")')
+    args = argparser.parse_args()
+
+    # ensure that the scsi_debug module is loaded
+    if os.path.isdir('/sys/module/scsi_debug'):
+        sys.stderr.write('The scsi_debug module is already loaded; please '
+                         'remove before running this test.\n')
+        sys.exit(1)
+    setup_vdevs()
+
+    if args.logfile:
+        daemon_log = open(args.logfile, mode='w')
+
+    # find which binary we're about to test: this also affects the D-Bus interface and object paths
+    testdir = os.path.abspath(os.path.dirname(__file__))
+    projdir = os.path.abspath(os.path.normpath(os.path.join(testdir, '..', '..', '..')))
+    daemon_bin = find_daemon(projdir)
+    storagedtestcase.daemon_bin = daemon_bin
+    daemon_bin_path = os.path.join(projdir, 'src', daemon_bin)
+
+    # start the devel tree daemon
+    daemon = subprocess.Popen([daemon_bin_path, '--replace', '--uninstalled',
+        '--force-load-modules'], shell=False, stdout=daemon_log, stderr=daemon_log)
+    # give the daemon some time to initialize
+    time.sleep(3)
+    daemon.poll()
+    if daemon.returncode != None:
+        print("Fatal: Unable to start the daemon process", file=sys.stderr)
+        sys.exit(1)
+
+    # Load all files in this directory whose name starts with 'test'
+    if args.testname:
+        for n in args.testname:
+            suite.addTests(unittest.TestLoader().loadTestsFromName(n))
+    else:
+        for test_cases in unittest.defaultTestLoader.discover(testdir):
+            suite.addTest(test_cases)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+
+    daemon.terminate()
+    daemon.wait()
+    daemon_log.close()
+
+    subprocess.call(['modprobe', '-r', 'scsi_debug'])
+
+    if result.wasSuccessful():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/src/tests/dbus-tests/storagedtestcase.py
+++ b/src/tests/dbus-tests/storagedtestcase.py
@@ -1,0 +1,58 @@
+import unittest
+import dbus
+import sys
+import subprocess
+import os
+import time
+
+daemon_bin = None
+test_devs = None
+
+class StoragedTestCase(unittest.TestCase):
+    iface_prefix = None
+    path_prefix = None
+    bus = None
+    vdevs = None
+    no_options = dbus.Dictionary(signature="sv")
+
+
+    @classmethod
+    def setUpClass(self):
+        if daemon_bin == 'udisksd':
+            self.iface_prefix = 'org..freedestkop.Udisks2'
+            self.path_prefix = '/org/freedesktop/UDisks2'
+        elif daemon_bin == 'storaged':
+            self.iface_prefix = 'org.storaged.Storaged'
+            self.path_prefix = '/org/storaged/Storaged'
+        self.bus = dbus.SystemBus()
+        self.vdevs = test_devs
+        assert len(self.vdevs) > 3;
+
+
+    @classmethod
+    def tearDownClass(self):\
+        pass
+
+
+    @classmethod
+    def get_object(self, iface_suffix, path_suffix):
+        try:
+            obj = self.bus.get_object(self.iface_prefix + iface_suffix, self.path_prefix + path_suffix)
+        except:
+            obj = None
+        return obj
+
+
+    @classmethod
+    def get_property(self, obj, iface_suffix, prop):
+        try:
+            res = obj.Get(self.iface_prefix + iface_suffix, prop, dbus_interface=dbus.PROPERTIES_IFACE)
+        except:
+            res = None
+        return res
+
+
+    @classmethod
+    def udev_settle(self):
+        subprocess.call(['udevadm', 'settle'])
+

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -1,0 +1,23 @@
+import unittest
+import storagedtestcase
+import dbus
+import os
+
+class StoragedBaseTest(storagedtestcase.StoragedTestCase):
+    '''This is a base test suite'''
+
+    def test_10_manager(self):
+        '''Testing the manager object presence'''
+        manager = self.get_object('', '/Manager')
+        self.assertIsNotNone(manager)
+        version = self.get_property(manager, '.Manager', 'Version')
+        self.assertIsNotNone(version)
+
+
+    def test_20_device_presence(self):
+        '''Test the debug devices are present on the bus'''
+        for d in self.vdevs:
+            dev_obj = self.get_object('', "/block_devices/%s" % os.path.basename(d))
+            self.assertIsNotNone(dev_obj)
+            self.assertTrue(os.path.exists(d))
+

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -1,0 +1,218 @@
+import unittest
+import storagedtestcase
+import dbus
+import os
+import subprocess
+import time
+
+class StoragedLVMTest(storagedtestcase.StoragedTestCase):
+    '''This is a basic LVM test suite'''
+
+    def _create_vg(self, vgname, devices):
+        self.udev_settle() # Since the devices might not be ready yet
+        manager = self.get_object('', '/Manager')
+        vg_path = manager.VolumeGroupCreate(vgname, devices, self.no_options,
+                dbus_interface=self.iface_prefix + '.Manager.LVM2')
+        self.udev_settle()
+        time.sleep(0.5)
+        vg = self.bus.get_object(self.iface_prefix, vg_path)
+        self.assertIsNotNone(vg)
+        self.assertEqual(subprocess.call(['vgs', vgname]), 0)
+        return vg
+
+
+    def _remove_vg(self, vg):
+        vgname = self.get_property(vg, '.VolumeGroup', 'Name')
+        vg.Delete(True, self.no_options, dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        self.assertNotEqual(subprocess.call(['vgs', vgname]), 0)
+
+
+    def test_10_linear(self):
+        '''Test linear (plain) LV functionality'''
+
+        vgname = 'storaged_test_vg'
+
+        # Use all the virtual devices but the last one
+        devs = dbus.Array()
+        for d in self.vdevs[:-1]:
+            dev_obj = self.get_object('', '/block_devices/' + os.path.basename(d))
+            self.assertIsNotNone(dev_obj)
+            devs.append(dev_obj)
+        vg = self._create_vg(vgname, devs)
+
+        # Create linear LV on the VG
+        vgsize = int(self.get_property(vg, '.VolumeGroup', 'Size'))
+        vg_freesize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        self.assertEqual(vgsize, vg_freesize)
+        lvname = 'storaged_test_lv'
+        lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize), self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        self.assertIsNotNone(lv_path)
+        self.assertEqual(subprocess.call(['lvs', os.path.join(vgname, lvname)]), 0)
+        lv = self.bus.get_object(self.iface_prefix, lv_path)
+        lv_block_path = lv.Activate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.assertIsNotNone(lv_block_path)
+        lvsize = int(self.get_property(lv, '.LogicalVolume', 'Size'))
+        self.assertEqual(lvsize, vgsize)
+
+        # Shrink the LV
+        lv.Deactivate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        lv.Resize(dbus.UInt64(lvsize/2), self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        lv_block_path = lv.Activate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        lv_block = self.bus.get_object(self.iface_prefix, lv_block_path)
+        self.assertIsNotNone(lv_block)
+        new_lvsize = int(self.get_property(lv, '.LogicalVolume', 'Size'))
+        self.assertGreater(lvsize, new_lvsize)
+
+        # Add one more device to the VG
+        new_dev_obj = self.get_object('', '/block_devices/' + os.path.basename(self.vdevs[-1]))
+        self.assertIsNotNone(new_dev_obj)
+        vg.AddDevice(new_dev_obj, self.no_options, dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        time.sleep(1)
+        new_vgsize = int(self.get_property(vg, '.VolumeGroup', 'Size'))
+        self.assertGreater(new_vgsize, vgsize)
+
+        # Resize the LV to the whole VG
+        lv.Deactivate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        lv.Resize(dbus.UInt64(new_vgsize), self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        new_lvsize = int(self.get_property(lv, '.LogicalVolume', 'Size'))
+        self.assertEqual(new_vgsize, new_lvsize)
+
+        # lvremove
+        lv.Deactivate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        lv.Delete(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        self.assertNotEqual(subprocess.call(['lvs', os.path.join(vgname, lvname)]), 0)
+
+        # vgremove
+        self._remove_vg(vg)
+
+
+    def test_20_thin(self):
+        '''Test thin volumes functionality'''
+
+        vgname = 'storaged_test_thin_vg'
+
+        # Use all the virtual devices
+        devs = dbus.Array()
+        for d in self.vdevs:
+            dev_obj = self.get_object('', '/block_devices/' + os.path.basename(d))
+            self.assertIsNotNone(dev_obj)
+            devs.append(dev_obj)
+        vg = self._create_vg(vgname, devs)
+
+        # Create thin pool on the VG
+        vgsize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        tpname = 'storaged_test_tp'
+        tp_path = vg.CreateThinPoolVolume(tpname, dbus.UInt64(vgsize), self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        self.assertIsNotNone(tp_path)
+        self.assertEqual(subprocess.call(['lvs', os.path.join(vgname, tpname)]), 0)
+        tp = self.bus.get_object(self.iface_prefix, tp_path)
+        tpsize = int(self.get_property(tp, '.LogicalVolume', 'Size'))
+
+        # Create thin volume in the pool with virtual size twice the backing pool
+        tvname = 'storaged_test_tv'
+        tv_path = vg.CreateThinVolume(tvname, dbus.UInt64(tpsize * 2), tp, self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        tv = self.bus.get_object(self.iface_prefix, tv_path)
+        self.assertIsNotNone(tv)
+        self.assertEqual(subprocess.call(['lvs', os.path.join(vgname, tvname)]), 0)
+
+        # Check the block device of the thin volume
+        lv_block_path = tv.Activate(self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        lv_block = self.bus.get_object(self.iface_prefix, lv_block_path)
+        self.assertIsNotNone(lv_block)
+        blocksize = int(self.get_property(lv_block, '.Block', 'Size'))
+        self.assertGreater(blocksize, vgsize)
+
+        # vgremove
+        self._remove_vg(vg)
+
+
+    def test_30_snapshot(self):
+        '''Test LVM snapshoting'''
+
+        vgname = 'storaged_test_snap_vg'
+
+        # Use all the virtual devices
+        devs = dbus.Array()
+        for d in self.vdevs:
+            dev_obj = self.get_object('', '/block_devices/' + os.path.basename(d))
+            self.assertIsNotNone(dev_obj)
+            devs.append(dev_obj)
+        vg = self._create_vg(vgname, devs)
+
+        # Create the origin LV
+        vgsize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        lvname = 'storaged_test_origin_lv'
+        lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize / 2), self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        lv = self.bus.get_object(self.iface_prefix, lv_path)
+        self.assertIsNotNone(lv)
+        self.assertEqual(subprocess.call(['lvs', os.path.join(vgname, lvname)]), 0)
+        time.sleep(1)
+
+        # Create the LV's snapshot
+        snapname = 'storaged_test_snap_lv'
+        vg_freesize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        snap_path = lv.CreateSnapshot(snapname, vg_freesize, self.no_options,
+                dbus_interface=self.iface_prefix + '.LogicalVolume')
+        self.udev_settle()
+        snap = self.bus.get_object(self.iface_prefix, snap_path)
+        self.assertIsNotNone(snap)
+
+        # vgremove
+        self._remove_vg(vg)
+
+
+    def test_40_cache(self):
+        '''Test LVM snapshoting'''
+
+        vgname = 'storaged_test_cache_vg'
+
+        # Use all the virtual devices
+        devs = dbus.Array()
+        for d in self.vdevs:
+            dev_obj = self.get_object('', '/block_devices/' + os.path.basename(d))
+            self.assertIsNotNone(dev_obj)
+            devs.append(dev_obj)
+        vg = self._create_vg(vgname, devs)
+
+        # Create the origin LV
+        vgsize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        lvname = 'storaged_test_origin_lv'
+        lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize / 2), self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        lv = self.bus.get_object(self.iface_prefix, lv_path)
+        self.assertIsNotNone(lv)
+        self.assertEqual(subprocess.call(['lvs', os.path.join(vgname, lvname)]), 0)
+        time.sleep(1)
+
+        # Create the caching LV
+        lvname = 'storaged_test_cache_lv'
+        vgsize = int(self.get_property(vg, '.VolumeGroup', 'FreeSize'))
+        lv_cache_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize / 2), self.no_options,
+                dbus_interface=self.iface_prefix + '.VolumeGroup')
+        self.udev_settle()
+        cache_lv = self.bus.get_object(self.iface_prefix, lv_cache_path)
+        self.assertIsNotNone(cache_lv)
+
+        # Add the cache to the origin
+        lv.CacheAttach('storaged_test_cache_lv', self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+
+        # vgremove
+        self._remove_vg(vg)
+

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -1,0 +1,30 @@
+import unittest
+import storagedtestcase
+import dbus
+import os
+import glob
+import time
+
+class StoragedISCSITest(storagedtestcase.StoragedTestCase):
+    '''Basic iSCSI test suite'''
+
+    def test_login_noauth(self):
+        host = os.getenv('TEST_ISCSI_HOST')
+        self.assertIsNotNone(host)
+        manager = self.get_object('', '/Manager')
+        (nodes, nodes_num) = manager.DiscoverSendTargets(host, 0, self.no_options,
+                dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
+        self.assertGreater(nodes_num, 0)
+        (iqn, tpg, host, port, iface) = nodes[0]
+        manager.Login(iqn, tpg, host, port, iface, self.no_options,
+                dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
+        time.sleep(1)
+        devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
+        self.assertGreater(len(devs), 0)
+        manager.Logout(iqn, tpg, host, port, iface, self.no_options,
+                dbus_interface=self.iface_prefix + '.Manager.ISCSI.Initiator')
+        time.sleep(1)
+        devs = glob.glob('/dev/disk/by-path/*%s*' % iqn)
+        self.assertEqual(len(devs), 0)
+
+


### PR DESCRIPTION
This should make the automated testing on RPM based systems a bit easier. Those who are not interested in RPM packaging should not encounter any problems. It should also build an rpm package outside of the git tree (like from the release tarball).