### PR TITLE
Log failures when formatting or creating partitions

### DIFF
--- a/src/storagedlinuxblock.c
+++ b/src/storagedlinuxblock.c
@@ -2703,6 +2703,17 @@ storaged_linux_block_teardown (StoragedBlock           *block,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+static void
+handle_format_failure (GDBusMethodInvocation *invocation,
+                       GError *error)
+{
+  storaged_warning ("%s", error->message);
+  if (invocation != NULL)
+    g_dbus_method_invocation_take_error (invocation, error);
+  else
+    g_error_free (error);
+}
+
 void
 storaged_linux_block_handle_format (StoragedBlock           *block,
                                     GDBusMethodInvocation   *invocation,
@@ -2910,12 +2921,11 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                               "wipefs -a %s",
                                               escaped_device))
     {
-      if (invocation != NULL)
-        g_dbus_method_invocation_return_error (invocation,
-                                               STORAGED_ERROR,
-                                               STORAGED_ERROR_FAILED,
-                                               "Error wiping device: %s",
-                                               error_message);
+      g_dbus_method_invocation_return_error (invocation,
+                                             STORAGED_ERROR,
+                                             STORAGED_ERROR_FAILED,
+                                             "Error wiping device: %s",
+                                             error_message);
       g_free (error_message);
       goto out;
     }
@@ -2934,10 +2944,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                           &error) == NULL)
     {
       g_prefix_error (&error, "Error synchronizing after initial wipe: ");
-      if (invocation != NULL)
-        g_dbus_method_invocation_take_error (invocation, error);
-      else
-        g_clear_error (&error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       goto out;
     }
 
@@ -2957,10 +2964,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
       if (!erase_device (block, object, daemon, caller_uid, erase_type, &error))
         {
           g_prefix_error (&error, "Error erasing device: ");
-          if (invocation != NULL)
-            g_dbus_method_invocation_take_error (invocation, error);
-          else
-            g_clear_error (&error);
+          handle_format_failure (invocation, error);
           goto out;
         }
     }
@@ -2983,12 +2987,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                                     "cryptsetup luksFormat \"%s\"",
                                                     escaped_device))
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation,
-                                                   STORAGED_ERROR,
-                                                   STORAGED_ERROR_FAILED,
-                                                   "Error creating LUKS device: %s",
-                                                   error_message);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Error creating LUKS device: %s", error_message));
           g_free (error_message);
           goto out;
         }
@@ -3002,10 +3002,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                                 &error) == NULL)
         {
           g_prefix_error (&error, "Error waiting for LUKS UUID: ");
-          if (invocation != NULL)
-            g_dbus_method_invocation_take_error (invocation, error);
-          else
-            g_clear_error (&error);
+          handle_format_failure (invocation, error);
           goto out;
         }
 
@@ -3025,12 +3022,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                                     escaped_device,
                                                     mapped_name))
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation,
-                                                   STORAGED_ERROR,
-                                                   STORAGED_ERROR_FAILED,
-                                                   "Error opening LUKS device: %s",
-                                                   error_message);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Error opening LUKS device: %s", error_message));
           g_free (error_message);
           goto out;
         }
@@ -3045,18 +3038,14 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
       if (cleartext_object == NULL)
         {
           g_prefix_error (&error, "Error waiting for LUKS cleartext device: ");
-          if (invocation != NULL)
-            g_dbus_method_invocation_take_error (invocation, error);
-          else
-            g_clear_error (&error);
+          handle_format_failure (invocation, error);
           goto out;
         }
       cleartext_block = storaged_object_get_block (cleartext_object);
       if (cleartext_block == NULL)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "LUKS cleartext device does not have block interface");
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "LUKS cleartext device does not have block interface"));
           goto out;
         }
 
@@ -3083,10 +3072,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
       if (!erase_device (block_to_mkfs, object_to_mkfs, daemon, caller_uid, erase_type, &error))
         {
           g_prefix_error (&error, "Error erasing cleartext device: ");
-          if (invocation != NULL)
-            g_dbus_method_invocation_take_error (invocation, error);
-          else
-            g_clear_error (&error);
+          handle_format_failure (invocation, error);
           goto out;
         }
     }
@@ -3097,12 +3083,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
       /* TODO: return an error if label is too long */
       if (strstr (fs_info->command_create_fs, "$LABEL") == NULL)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation,
-                                                   STORAGED_ERROR,
-                                                   STORAGED_ERROR_NOT_SUPPORTED,
-                                                   "File system type %s does not support labels",
-                                                   type);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "File system type %s does not support labels", type));
           goto out;
         }
     }
@@ -3130,12 +3112,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                                       NULL, /* input_string */
                                                       "%s", command))
           {
-            if (invocation != NULL)
-              g_dbus_method_invocation_return_error (invocation,
-                                                     STORAGED_ERROR,
-                                                     STORAGED_ERROR_FAILED,
-                                                     "Error creating file system: %s",
-                                                     error_message);
+            handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                   "Error creating file system: %s", error_message));
             g_free (error_message);
             goto out;
           }
@@ -3147,7 +3125,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
         device_name = g_strdup (storaged_block_get_device (block));
         if (! bd_part_create_table (device_name, part_table_type, TRUE, &error))
           {
-            g_dbus_method_invocation_take_error (invocation, error);
+            handle_format_failure (invocation, error);
             goto out;
           }
       }
@@ -3168,10 +3146,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
       g_prefix_error (&error,
                       "Error synchronizing after formatting with type `%s': ",
                       type);
-      if (invocation != NULL)
-        g_dbus_method_invocation_take_error (invocation, error);
-      else
-        g_clear_error (&error);
+      handle_format_failure (invocation, error);
       goto out;
     }
 
@@ -3182,18 +3157,14 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
 
       if (mkdtemp (tos_dir) == NULL)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot create directory %s: %m", tos_dir);
+            handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                   "Cannot create directory %s: %m", tos_dir));
           goto out;
         }
       if (mount (storaged_block_get_device (block_to_mkfs), tos_dir, type, 0, NULL) != 0)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot mount %s at %s: %m",
-                                                   storaged_block_get_device (block_to_mkfs),
-                                                   tos_dir);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Cannot mount %s at %s: %m", storaged_block_get_device (block_to_mkfs), tos_dir));
           if (rmdir (tos_dir) != 0)
             {
               storaged_warning ("Error removing directory %s: %m", tos_dir);
@@ -3202,9 +3173,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
         }
       if (chown (tos_dir, caller_uid, caller_gid) != 0)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot chown %s to uid=%u and gid=%u: %m", tos_dir, caller_uid, caller_gid);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Cannot chown %s to uid=%u and gid=%u: %m", tos_dir, caller_uid, caller_gid));
           if (umount (tos_dir) != 0)
             {
               storaged_warning ("Error unmounting directory %s: %m", tos_dir);
@@ -3218,9 +3188,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
         }
       if (chmod (tos_dir, 0700) != 0)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot chmod %s to mode 0700: %m", tos_dir);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Cannot chmod %s to mode 0700: %m", tos_dir));
           if (umount (tos_dir) != 0)
             {
               storaged_warning ("Error unmounting directory %s: %m", tos_dir);
@@ -3235,9 +3204,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
 
       if (umount (tos_dir) != 0)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot unmount %s: %m", tos_dir);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Cannot unmount %s: %m", tos_dir));
           if (rmdir (tos_dir) != 0)
             {
               storaged_warning ("Error removing directory %s: %m", tos_dir);
@@ -3247,9 +3215,8 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
 
       if (rmdir (tos_dir) != 0)
         {
-          if (invocation != NULL)
-            g_dbus_method_invocation_return_error (invocation, STORAGED_ERROR, STORAGED_ERROR_FAILED,
-                                                   "Cannot remove directory %s: %m", tos_dir);
+          handle_format_failure (invocation, g_error_new (STORAGED_ERROR, STORAGED_ERROR_FAILED,
+                                 "Cannot remove directory %s: %m", tos_dir));
           goto out;
         }
     }
@@ -3266,7 +3233,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
                                                      &error))
             {
               g_prefix_error (&error, "Error setting partition type after formatting: ");
-              g_dbus_method_invocation_take_error (invocation, error);
+              handle_format_failure (invocation, error);
               goto out;
             }
         }
@@ -3287,7 +3254,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
             {
               if (!add_remove_fstab_entry (block_to_mkfs, NULL, details, &error))
                 {
-                  g_dbus_method_invocation_take_error (invocation, error);
+                  handle_format_failure (invocation, error);
                   goto out;
                 }
             }
@@ -3295,7 +3262,7 @@ storaged_linux_block_handle_format (StoragedBlock           *block,
             {
               if (!add_remove_crypttab_entry (block, NULL, details, &error))
                 {
-                  g_dbus_method_invocation_take_error (invocation, error);
+                  handle_format_failure (invocation, error);
                   goto out;
                 }
             }


### PR DESCRIPTION
Although a better handling of no-block errors would be nice, at
the very least we should be logging these failures and not dropping
the failure messages on the floor.