### PR TITLE
ISCSI: Add SessionsSupported property

### DIFF
--- a/modules/iscsi/data/org.storaged.Storaged.iscsi.xml
+++ b/modules/iscsi/data/org.storaged.Storaged.iscsi.xml
@@ -181,6 +181,13 @@
       <arg name="iface" direction="in" type="s"/>
       <arg name="options" type="a{sv}" direction="in"/>
     </method>
+
+    <!--
+        SessionsSupported: Whether or not this version of Storaged
+        supports ISCSI.Session objects.
+    -->
+    <property name="SessionsSupported" type="b" access="read"/>
+
   </interface>
 
   <!--

--- a/modules/iscsi/storagedlinuxmanageriscsiinitiator.c
+++ b/modules/iscsi/storagedlinuxmanageriscsiinitiator.c
@@ -184,6 +184,10 @@ storaged_linux_manager_iscsi_initiator_init (StoragedLinuxManagerISCSIInitiator 
 
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (manager),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
+#ifdef HAVE_LIBISCSI_GET_SESSION_INFOS
+  storaged_manager_iscsi_initiator_set_sessions_supported (STORAGED_MANAGER_ISCSI_INITIATOR (manager),
+                                                           TRUE);
+#endif
 }
 
 /**


### PR DESCRIPTION
So that clients like Cockpit can adapt accordingly.