### PR TITLE
Tests: Install and eventually backup the polkit data files

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -8,6 +8,7 @@ import argparse
 import unittest
 import storagedtestcase
 import glob
+import shutil
 
 
 VDEV_SIZE = 300000000  # size of virtual test device
@@ -53,6 +54,30 @@ def setup_vdevs():
     storagedtestcase.test_devs = vdevs
 
 
+def install_new_policy(projdir):
+    '''Copies the polkit policies to the system directory and backs up eventually the existing files.
+       Returns a list of tuples containing (file_name, should_be_restored).'''
+    files = glob.glob(projdir + '/data/*.policy') + glob.glob(projdir + '/modules/*/data/*.policy')
+    restore_list = []
+    for f in files:
+        tgt = '/usr/share/polkit-1/actions/' + os.path.basename(f)
+        if os.path.exists(tgt):
+            shutil.move(tgt, '/tmp/')
+            restore_list.append((tgt, True))
+        else:
+            restore_list.append((tgt, False))
+        shutil.copy(f, '/usr/share/polkit-1/actions/')
+    return restore_list
+
+
+def restore_policy(restore_list):
+    for (fname, restore) in restore_list:
+        if restore:
+            shutil.move('/tmp/' + os.path.basename(fname), fname)
+        else:
+            os.remove(fname)
+
+
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     daemon_log = sys.stdout
@@ -74,9 +99,11 @@ if __name__ == '__main__':
     if args.logfile:
         daemon_log = open(args.logfile, mode='w')
 
-    # find which binary we're about to test: this also affects the D-Bus interface and object paths
     testdir = os.path.abspath(os.path.dirname(__file__))
     projdir = os.path.abspath(os.path.normpath(os.path.join(testdir, '..', '..', '..')))
+
+    policy_files = install_new_policy(projdir)
+    # find which binary we're about to test: this also affects the D-Bus interface and object paths
     daemon_bin = find_daemon(projdir)
     storagedtestcase.daemon_bin = daemon_bin
     daemon_bin_path = os.path.join(projdir, 'src', daemon_bin)
@@ -103,6 +130,8 @@ if __name__ == '__main__':
     daemon.terminate()
     daemon.wait()
     daemon_log.close()
+
+    restore_policy(policy_files)
 
     subprocess.call(['modprobe', '-r', 'scsi_debug'])
 


### PR DESCRIPTION
This should save some of the manual work when trying to run the
tests: Let's save the old polkit data files, install the ones from
the source tree and then restore the saved ones at the end of
the testing. Not perfect but simplifies switching between branches.