### PR TITLE
Fix #46: LVM2 Plugin: cache split using unsafe option

### DIFF
--- a/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
+++ b/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.xml
@@ -555,6 +555,18 @@
       <arg name="options" type= "a{sv}" direction="in"/>
     </method>
 
+    <!-- CacheDetach:
+         @options: Additional options.
+         @since: 2.6.3
+
+         Detaches the cached LV from its cache.
+
+         No additional options are currently defined.
+    -->
+    <method name="CacheDetach">
+        <arg name="options" type= "a{sv}" direction="in"/>
+    </method>
+
   </interface>
 
   <!-- ********************************************************************** -->

--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -1129,9 +1129,10 @@ return TRUE;
 
 
 static gboolean
-handle_cache_split (UDisksLogicalVolume  *volume_,
-                    GDBusMethodInvocation  *invocation,
-                    GVariant               *options)
+handle_cache_detach_or_split (UDisksLogicalVolume  *volume_,
+                              GDBusMethodInvocation  *invocation,
+                              GVariant               *options,
+                              gboolean               destroy)
 {
 #ifndef HAVE_LVMCACHE
 
@@ -1189,7 +1190,8 @@ handle_cache_split (UDisksLogicalVolume  *volume_,
 
   cmd = g_string_new ("");
   g_string_append_printf (cmd,
-                          "lvconvert --splitcache %s/%s -y",
+                          "lvconvert %s %s/%s -y",
+                          destroy ? "--splitcache" : "--uncache",
                           escaped_group_name,
                           escaped_origin_name);
 
@@ -1226,6 +1228,22 @@ out:
 #endif /* HAVE_LVMCACHE */
 }
 
+static gboolean
+handle_cache_split (UDisksLogicalVolume    *volume_,
+                    GDBusMethodInvocation  *invocation,
+                    GVariant               *options)
+{
+  return handle_cache_detach_or_split(volume_, invocation, options, TRUE);
+}
+
+static gboolean
+handle_cache_detach (UDisksLogicalVolume    *volume_,
+                     GDBusMethodInvocation  *invocation,
+                     GVariant               *options)
+{
+  return handle_cache_detach_or_split(volume_, invocation, options, FALSE);
+}
+
 /* ---------------------------------------------------------------------------------------------------- */
 
 static void
@@ -1240,4 +1258,5 @@ logical_volume_iface_init (UDisksLogicalVolumeIface *iface)
 
   iface->handle_cache_attach = handle_cache_attach;
   iface->handle_cache_split = handle_cache_split;
+  iface->handle_cache_detach = handle_cache_detach;
 }


### PR DESCRIPTION
Storaged still uses the unsafe '--splitcache' option. Here's the fix not depending on libblockdev. We may eventually switch to libblockdev backend once it has all the features. Until then this should be sufficient.