### PR TITLE
Core: Force re-applying configuration on system resume from sleep

### DIFF
--- a/src/udiskslinuxdriveobject.c
+++ b/src/udiskslinuxdriveobject.c
@@ -752,6 +752,9 @@ udisks_linux_drive_object_uevent (UDisksLinuxDriveObject *object,
         }
     }
 
+  if (g_strcmp0 (action, "reconfigure") == 0)
+    conf_changed = TRUE;
+
   if (conf_changed)
     apply_configuration (object);
 }


### PR DESCRIPTION
When the system suspends or hibernates the ATA drives reset their configuration to default. This for example resets the APM level. This is an attempt to fix the problem. Storaged subscribes to logind D-Bus signal sent on system suspending or resuming and on resume event scans the drive configuration files and for each such drive synthesizes a fake "reconfigure" event that makes the uevent handling routines to apply the configuration settings again. Looks to fix the issue #72 on my system.