### PR TITLE
Build system: Add rpm make taget

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,3 +30,14 @@ shortlog:
 
 clean-local:
 	rm -f *~
+
+RPMDIR = `readlink -f $(top_builddir)/packaging`
+SRCDIR = `readlink -f $(top_srcdir)`
+rpm: dist-bzip2
+	rpmbuild \
+		--define "_sourcedir $(SRCDIR)" \
+		--define "_specdir $(RPMDIR)" \
+		--define "_builddir $(RPMDIR)" \
+		--define "_srcrpmdir $(RPMDIR)" \
+		--define "_rpmdir $(RPMDIR)" \
+		-ba $(SRCDIR)/packaging/storaged.spec

--- a/packaging/storaged.spec.in
+++ b/packaging/storaged.spec.in
@@ -11,7 +11,7 @@
 
 Name:    storaged
 Summary: Disk Manager
-Version: 2.6.2
+Version: 2.6.3
 Release: 1%{?dist}
 License: GPLv2+
 Group:   System Environment/Libraries


### PR DESCRIPTION
Just for convenience and ease of testing: make rpm now creates packages in the 'packaging' subdirectory.