### PR TITLE
Add option to test also the system installed storaged instance

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -12,6 +12,7 @@ class StoragedBaseTest(storagedtestcase.StoragedTestCase):
         self.assertIsNotNone(manager)
         version = self.get_property(manager, '.Manager', 'Version')
         self.assertIsNotNone(version)
+        manager.EnableModules(True, dbus_interface=self.iface_prefix + '.Manager')
 
 
     def test_20_device_presence(self):


### PR DESCRIPTION
These are two patches: first calls the EnableModules method in the first test te ensure the rest of the test suite works and the second adds option not to replace the system daemon and run the tests on the installed one.