### PR TITLE
Core: Return correct error type on unsupported FS label

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -3083,7 +3083,7 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
       /* TODO: return an error if label is too long */
       if (strstr (fs_info->command_create_fs, "$LABEL") == NULL)
         {
-          handle_format_failure (invocation, g_error_new (UDISKS_ERROR, UDISKS_ERROR_FAILED,
+          handle_format_failure (invocation, g_error_new (UDISKS_ERROR, UDISKS_ERROR_NOT_SUPPORTED,
                                  "File system type %s does not support labels", type));
           goto out;
         }


### PR DESCRIPTION
This is a tiny regression introduced by the commit 5f22a02d and causing the integration tests to fail. Storaged should return the "NotSupported" error instead of "Fail" when trying to label a file system that does not support labels.