### PR TITLE
Build: Add srpm make target; autogenerate rpm versions from git hash.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,3 +41,11 @@ rpm: dist-bzip2
 		--define "_srcrpmdir $(RPMDIR)" \
 		--define "_rpmdir $(RPMDIR)" \
 		-ba $(SRCDIR)/packaging/storaged.spec
+srpm: dist-bzip2
+	rpmbuild \
+		--define "_sourcedir $(SRCDIR)" \
+		--define "_specdir $(RPMDIR)" \
+		--define "_builddir $(RPMDIR)" \
+		--define "_srcrpmdir $(RPMDIR)" \
+		--define "_rpmdir $(RPMDIR)" \
+		-bs $(SRCDIR)/packaging/storaged.spec

--- a/packaging/storaged.spec.in
+++ b/packaging/storaged.spec.in
@@ -8,11 +8,18 @@
 %global with_libblockdev_part           @have_libblockdev_part_spec@
 
 %define is_fedora                       0%{?rhel} == 0
+%define is_git                          %(git show > /dev/null 2>&1 && echo 1 || echo 0)
+%define git_hash                        %(git show --pretty=format:%h || true)
+%define build_date                      %(date '+%Y%m%d')
 
 Name:    storaged
 Summary: Disk Manager
 Version: 2.6.3
+%if %{is_git} == 0
 Release: 1%{?dist}
+%else
+Release: 0.%{build_date}git%{git_hash}%{?dist}
+%endif
 License: GPLv2+
 Group:   System Environment/Libraries
 URL:     https://github.com/storaged-project/storaged


### PR DESCRIPTION
Here's another attempt to create testing rpm packages from git tree with automatic versioning. This time it's purely in the spec file: if the rpmbuild command is run from within the git tree the resulting rpm is versioned by the git hash. The usual release version is used otherwise.

I have also created a srpm target to avoid re-building the binary rpms when preparing a source package for other build services (COPR).