### PR TITLE
Misc fixes

### DIFF
--- a/modules/bcache/udisksbcachemoduleiface.c
+++ b/modules/bcache/udisksbcachemoduleiface.c
@@ -62,7 +62,6 @@ udisks_module_teardown (UDisksDaemon *daemon)
 static gboolean
 bcache_block_check (UDisksObject *object)
 {
-  const gchar *devname = NULL;
   UDisksLinuxDevice *device = NULL;
   gboolean rval = FALSE;
 
@@ -70,12 +69,9 @@ bcache_block_check (UDisksObject *object)
 
   /* Check device name */
   device = udisks_linux_block_object_get_device (UDISKS_LINUX_BLOCK_OBJECT (object));
-  devname = g_strdup (g_udev_device_get_device_file (device->udev_device));
-
-  rval = g_str_has_prefix (devname, "/dev/bcache");
-
-  g_free ((gpointer) devname);
-
+  rval = g_str_has_prefix (g_udev_device_get_device_file (device->udev_device),
+                            "/dev/bcache");
+  g_object_unref(device);
   return rval;
 }
 

--- a/modules/btrfs/udisksbtrfsmoduleiface.c
+++ b/modules/btrfs/udisksbtrfsmoduleiface.c
@@ -66,6 +66,7 @@ btrfs_block_check (UDisksObject *object)
 {
   const gchar *fs_type = NULL;
   UDisksLinuxDevice *device = NULL;
+  int rc = 0;
 
   g_return_val_if_fail (UDISKS_IS_LINUX_BLOCK_OBJECT (object), FALSE);
 
@@ -73,7 +74,10 @@ btrfs_block_check (UDisksObject *object)
   device = udisks_linux_block_object_get_device (UDISKS_LINUX_BLOCK_OBJECT (object));
   fs_type = g_udev_device_get_property (device->udev_device, "ID_FS_TYPE");
 
-  return g_strcmp0 (fs_type, "btrfs") == 0;
+  rc = g_strcmp0 (fs_type, "btrfs");
+  g_object_unref(device);
+
+  return rc == 0;
 }
 
 static void

--- a/modules/lvm2/udiskslinuxvolumegroupobject.c
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.c
@@ -306,7 +306,6 @@ update_etctabs (UDisksLinuxVolumeGroupObject *object)
   g_hash_table_iter_init (&iter, object->logical_volumes);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
-      const gchar *name = key;
       UDisksLinuxLogicalVolumeObject *volume = value;
 
       udisks_linux_logical_volume_object_update_etctabs (volume);

--- a/modules/lvm2/udiskslinuxvolumegroupobject.c
+++ b/modules/lvm2/udiskslinuxvolumegroupobject.c
@@ -453,6 +453,8 @@ update_block (UDisksLinuxBlockObject       *block_object,
           {
             block_object_update_lvm_iface (block_object, g_dbus_object_get_object_path (G_DBUS_OBJECT (lv_object)));
           }
+
+        g_object_unref(device);
       }
   }
 

--- a/modules/lvm2/udiskslvmhelper.c
+++ b/modules/lvm2/udiskslvmhelper.c
@@ -70,20 +70,25 @@ static GVariant *
 list_volume_groups (void)
 {
   lvm_t lvm;
-  struct dm_list *vg_names;
-  struct lvm_str_list *vg_name;
+  struct dm_list *vg_names = NULL;
+  struct lvm_str_list *vg_name = NULL;
   GVariantBuilder result;
 
   lvm = init_lvm ();
 
-  g_variant_builder_init (&result, G_VARIANT_TYPE ("as"));
-  vg_names = lvm_list_vg_names (lvm);
-  dm_list_iterate_items (vg_name, vg_names)
+  if (lvm)
     {
-      g_variant_builder_add (&result, "s", vg_name->str);
+      g_variant_builder_init (&result, G_VARIANT_TYPE ("as"));
+      vg_names = lvm_list_vg_names (lvm);
+      if (vg_names)
+        {
+          dm_list_iterate_items (vg_name, vg_names)
+            {
+              g_variant_builder_add (&result, "s", vg_name->str);
+            }
+        }
+      lvm_quit (lvm);
     }
-
-  lvm_quit (lvm);
   return g_variant_builder_end (&result);
 }
 

--- a/modules/zram/udiskszrammoduleiface.c
+++ b/modules/zram/udiskszrammoduleiface.c
@@ -62,7 +62,6 @@ udisks_module_teardown (UDisksDaemon *daemon)
 static gboolean
 zram_block_check (UDisksObject *object)
 {
-  const gchar *devname = NULL;
   UDisksLinuxDevice *device = NULL;
   gboolean rval = FALSE;
 
@@ -70,11 +69,9 @@ zram_block_check (UDisksObject *object)
 
   /* Check device name */
   device = udisks_linux_block_object_get_device (UDISKS_LINUX_BLOCK_OBJECT (object));
-  devname = g_strdup (g_udev_device_get_device_file (device->udev_device));
-
-  rval = g_str_has_prefix (devname, "/dev/zram");
-
-  g_free ((gpointer) devname);
+  rval = g_str_has_prefix (g_udev_device_get_device_file (device->udev_device),
+                            "/dev/zram");
+  g_object_unref(device);
 
   return rval;
 }

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -328,8 +328,7 @@ gboolean
 udisks_linux_drive_ata_update (UDisksLinuxDriveAta    *drive,
                                UDisksLinuxDriveObject *object)
 {
-  UDisksLinuxDevice *device
-;
+  UDisksLinuxDevice *device;
   device = udisks_linux_drive_object_get_device (object, TRUE /* get_hw */);
   if (device == NULL)
     goto out;


### PR DESCRIPTION
With these changes the daemon can make it through the lvm dbus test without leaking tons of memory or running out of file descriptors, assuming it doesn't seg. fault before we are done.  There are at least 2 distinct seg. faults that I'm aware of that still exist, and I will **try** to track them down too.  Just to clarify, the daemon's dbus API is not being exercised, it's just responding to udev events which occur during the lvm dbus unit test.

The fix in this PR for the seg. fault prevents the crash of the lvm helper, but we need to understand why we are failing from lvm2app.  I'm also seeing warning where the lvm helper is failing to retrieve information, so the dbus objects will be incorrect.