### PR TITLE
Some GLib-GObject-CRITICAL  fixes

### DIFF
--- a/modules/lvm2/udiskslvm2moduleiface.c
+++ b/modules/lvm2/udiskslvm2moduleiface.c
@@ -154,7 +154,6 @@ lvm_update_from_variant (GPid      pid,
           udisks_linux_volume_group_object_destroy (group);
           g_dbus_object_manager_server_unexport (manager,
                                                  g_dbus_object_get_object_path (G_DBUS_OBJECT (group)));
-          g_object_unref (G_OBJECT (group));
           g_hash_table_iter_remove (&vg_name_iter);
         }
     }

--- a/modules/lvm2/udiskslvmhelper.c
+++ b/modules/lvm2/udiskslvmhelper.c
@@ -74,11 +74,11 @@ list_volume_groups (void)
   struct lvm_str_list *vg_name = NULL;
   GVariantBuilder result;
 
+  g_variant_builder_init (&result, G_VARIANT_TYPE ("as"));
   lvm = init_lvm ();
 
   if (lvm)
     {
-      g_variant_builder_init (&result, G_VARIANT_TYPE ("as"));
       vg_names = lvm_list_vg_names (lvm);
       if (vg_names)
         {

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -119,12 +119,14 @@ udisks_daemon_finalize (GObject *object)
   g_clear_object (&daemon->authority);
   g_object_unref (daemon->object_manager);
   g_object_unref (daemon->linux_provider);
-  g_object_unref (daemon->mount_monitor);
   g_object_unref (daemon->connection);
+
+  /* Modules use the monitors and try to reference them when cleaning up */
+  udisks_module_manager_unload_modules (daemon->module_manager);
+  g_object_unref (daemon->mount_monitor);
   g_object_unref (daemon->fstab_monitor);
   g_object_unref (daemon->crypttab_monitor);
 
-  udisks_module_manager_unload_modules (daemon->module_manager);
   g_clear_object (&daemon->module_manager);
 
   g_clear_object (&daemon->config_manager);


### PR DESCRIPTION
This fixes some of the `GLib-GObject-CRITICAL` messages that were being spewed when running the lvm dbus tests with storaged running.  A fairly large number of `GLib-GObject-WARNING` messages exist.

Note: core files created by:

``` bash
export G_DEBUG=fatal_criticals
```

To facilitate debug.  Ideally we should be running clean with

``` bash
export G_DEBUG=fatal_warnings
```

But there is much to fix before then.
