### PR TITLE
Don't include optional parameters in 'Missing parameter' message

### DIFF
--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -1632,7 +1632,7 @@ add_remove_crypttab_entry (UDisksBlock *block,
           g_set_error (error,
                        UDISKS_ERROR,
                        UDISKS_ERROR_FAILED,
-                       "Missing passphrase-path, options or passphrase-contents parameter in entry to add");
+                       "Missing options or passphrase-contents parameter in entry to add");
           goto out;
         }
 


### PR DESCRIPTION
The passphrase-path parameter is optional