### PR TITLE
Use targetcli instead of scsi_debug

### DIFF
--- a/src/tests/dbus-tests/targetcli_config.json
+++ b/src/tests/dbus-tests/targetcli_config.json
@@ -1,0 +1,239 @@
+{
+  "fabric_modules": [],
+  "storage_objects": [
+    {
+      "attributes": {
+        "block_size": 512,
+        "emulate_3pc": 1,
+        "emulate_caw": 1,
+        "emulate_dpo": 1,
+        "emulate_fua_read": 1,
+        "emulate_fua_write": 1,
+        "emulate_model_alias": 1,
+        "emulate_rest_reord": 0,
+        "emulate_tas": 1,
+        "emulate_tpu": 0,
+        "emulate_tpws": 0,
+        "emulate_ua_intlck_ctrl": 0,
+        "emulate_write_cache": 1,
+        "enforce_pr_isids": 1,
+        "force_pr_aptpl": 0,
+        "is_nonrot": 0,
+        "max_unmap_block_desc_count": 1,
+        "max_unmap_lba_count": 8192,
+        "max_write_same_len": 4096,
+        "optimal_sectors": 2048,
+        "pi_prot_format": 0,
+        "pi_prot_type": 0,
+        "queue_depth": 128,
+        "unmap_granularity": 1,
+        "unmap_granularity_alignment": 0,
+        "unmap_zeroes_data": 0
+      },
+      "dev": "/var/tmp/storaged_test_disk4",
+      "name": "storaged_test_disk4",
+      "plugin": "fileio",
+      "size": 524288000,
+      "write_back": true,
+      "wwn": "65541bbc-0ffc-42cb-b639-6ce91a818511"
+    },
+    {
+      "attributes": {
+        "block_size": 512,
+        "emulate_3pc": 1,
+        "emulate_caw": 1,
+        "emulate_dpo": 1,
+        "emulate_fua_read": 1,
+        "emulate_fua_write": 1,
+        "emulate_model_alias": 1,
+        "emulate_rest_reord": 0,
+        "emulate_tas": 1,
+        "emulate_tpu": 0,
+        "emulate_tpws": 0,
+        "emulate_ua_intlck_ctrl": 0,
+        "emulate_write_cache": 1,
+        "enforce_pr_isids": 1,
+        "force_pr_aptpl": 0,
+        "is_nonrot": 0,
+        "max_unmap_block_desc_count": 1,
+        "max_unmap_lba_count": 8192,
+        "max_write_same_len": 4096,
+        "optimal_sectors": 2048,
+        "pi_prot_format": 0,
+        "pi_prot_type": 0,
+        "queue_depth": 128,
+        "unmap_granularity": 1,
+        "unmap_granularity_alignment": 0,
+        "unmap_zeroes_data": 0
+      },
+      "dev": "/var/tmp/storaged_test_disk3",
+      "name": "storaged_test_disk3",
+      "plugin": "fileio",
+      "size": 524288000,
+      "write_back": true,
+      "wwn": "5282611e-2e74-4019-8ca5-d8ceb09dfa15"
+    },
+    {
+      "attributes": {
+        "block_size": 512,
+        "emulate_3pc": 1,
+        "emulate_caw": 1,
+        "emulate_dpo": 1,
+        "emulate_fua_read": 1,
+        "emulate_fua_write": 1,
+        "emulate_model_alias": 1,
+        "emulate_rest_reord": 0,
+        "emulate_tas": 1,
+        "emulate_tpu": 0,
+        "emulate_tpws": 0,
+        "emulate_ua_intlck_ctrl": 0,
+        "emulate_write_cache": 1,
+        "enforce_pr_isids": 1,
+        "force_pr_aptpl": 0,
+        "is_nonrot": 0,
+        "max_unmap_block_desc_count": 1,
+        "max_unmap_lba_count": 8192,
+        "max_write_same_len": 4096,
+        "optimal_sectors": 2048,
+        "pi_prot_format": 0,
+        "pi_prot_type": 0,
+        "queue_depth": 128,
+        "unmap_granularity": 1,
+        "unmap_granularity_alignment": 0,
+        "unmap_zeroes_data": 0
+      },
+      "dev": "/var/tmp/storaged_test_disk2",
+      "name": "storaged_test_disk2",
+      "plugin": "fileio",
+      "size": 524288000,
+      "write_back": true,
+      "wwn": "dd927109-b9e7-462c-b95a-ae7878623713"
+    },
+    {
+      "attributes": {
+        "block_size": 512,
+        "emulate_3pc": 1,
+        "emulate_caw": 1,
+        "emulate_dpo": 1,
+        "emulate_fua_read": 1,
+        "emulate_fua_write": 1,
+        "emulate_model_alias": 1,
+        "emulate_rest_reord": 0,
+        "emulate_tas": 1,
+        "emulate_tpu": 0,
+        "emulate_tpws": 0,
+        "emulate_ua_intlck_ctrl": 0,
+        "emulate_write_cache": 1,
+        "enforce_pr_isids": 1,
+        "force_pr_aptpl": 0,
+        "is_nonrot": 0,
+        "max_unmap_block_desc_count": 1,
+        "max_unmap_lba_count": 8192,
+        "max_write_same_len": 4096,
+        "optimal_sectors": 2048,
+        "pi_prot_format": 0,
+        "pi_prot_type": 0,
+        "queue_depth": 128,
+        "unmap_granularity": 1,
+        "unmap_granularity_alignment": 0,
+        "unmap_zeroes_data": 0
+      },
+      "dev": "/var/tmp/storaged_test_disk1",
+      "name": "storaged_test_disk1",
+      "plugin": "fileio",
+      "size": 524288000,
+      "write_back": true,
+      "wwn": "0604a813-ce79-45fa-a9ff-eaf82188594e"
+    }
+  ],
+  "targets": [
+    {
+      "fabric": "loopback",
+      "tpgs": [
+        {
+          "attributes": {
+            "fabric_prot_type": 0
+          },
+          "enable": true,
+          "luns": [
+            {
+              "alias": "ea4c386be4",
+              "index": 0,
+              "storage_object": "/backstores/fileio/storaged_test_disk4"
+            }
+          ],
+          "node_acls": [],
+          "portals": [],
+          "tag": 1
+        }
+      ],
+      "wwn": "naa.50014055ba294ff9"
+    },
+    {
+      "fabric": "loopback",
+      "tpgs": [
+        {
+          "attributes": {
+            "fabric_prot_type": 0
+          },
+          "enable": true,
+          "luns": [
+            {
+              "alias": "7a8a8952a0",
+              "index": 0,
+              "storage_object": "/backstores/fileio/storaged_test_disk3"
+            }
+          ],
+          "node_acls": [],
+          "portals": [],
+          "tag": 1
+        }
+      ],
+      "wwn": "naa.5001405929853f55"
+    },
+    {
+      "fabric": "loopback",
+      "tpgs": [
+        {
+          "attributes": {
+            "fabric_prot_type": 0
+          },
+          "enable": true,
+          "luns": [
+            {
+              "alias": "d0173d579b",
+              "index": 0,
+              "storage_object": "/backstores/fileio/storaged_test_disk2"
+            }
+          ],
+          "node_acls": [],
+          "portals": [],
+          "tag": 1
+        }
+      ],
+      "wwn": "naa.50014054a77f7fa2"
+    },
+    {
+      "fabric": "loopback",
+      "tpgs": [
+        {
+          "attributes": {
+            "fabric_prot_type": 0
+          },
+          "enable": true,
+          "luns": [
+            {
+              "alias": "d4a2f5275c",
+              "index": 0,
+              "storage_object": "/backstores/fileio/storaged_test_disk1"
+            }
+          ],
+          "node_acls": [],
+          "portals": [],
+          "tag": 1
+        }
+      ],
+      "wwn": "naa.5001405cf0711e93"
+    }
+  ]
+}

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -1,5 +1,6 @@
 import dbus
 import os
+import time
 
 import storagedtestcase
 
@@ -19,7 +20,11 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         device.Format(ftype, self.no_options, dbus_interface=self.iface_prefix + '.Block')
 
     def _remove_partition(self, part):
-        part.Delete(self.no_options, dbus_interface=self.iface_prefix + '.Partition')
+        try:
+            part.Delete(self.no_options, dbus_interface=self.iface_prefix + '.Partition')
+        except dbus.exceptions.DBusException:
+            time.sleep(1)
+            part.Delete(self.no_options, dbus_interface=self.iface_prefix + '.Partition')
 
     def test_create_mbr_partition(self):
         disk = self.get_object('', '/block_devices/' + os.path.basename(self.vdevs[0]))


### PR DESCRIPTION
scsi_debug can create multiple SCSI devices, but all share the same backing
store (in RAM). Thus, they all contain the same data which causes serious issues
when used as PVs for LVM etc. Instead, let's use targetcli (LIO) which also allows us to
create fake SCSI devices, but each with it's own backing storage.
