### PR TITLE
Adapt to libblockdev 2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,13 +304,13 @@ if test "x$enable_btrfs" = "xyes" \
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
-    CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
+    CFLAGS="$GLIB_CFLAGS"
     LDFLAGS="$GLIB_LIBS"
     # We don't use AC_CHECK_HEADER to avoid these warnings:
     #   - accepted by the compiler, rejected by the preprocessor!
     #   - proceeding with the compiler's result
     AC_MSG_CHECKING(["libblockdev-btrfs presence"])
-    AC_TRY_COMPILE([#include <btrfs.h>], [],
+    AC_TRY_COMPILE([#include <blockdev/btrfs.h>], [],
                    [AC_MSG_RESULT([yes])
                     AC_DEFINE(HAVE_BTRFS, 1, [Define, if libblockdev-btrfs is available])
                     have_btrfs=yes],
@@ -319,7 +319,7 @@ if test "x$enable_btrfs" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    BTRFS_CFLAGS="-I/usr/include/blockdev"
+    BTRFS_CFLAGS=""
     BTRFS_LIBS="-lbd_btrfs"
 
     if test "x$have_btrfs" = "xno"; then
@@ -341,18 +341,18 @@ if test "x$enable_zram" = "xyes" \
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
-    CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
+    CFLAGS="$GLIB_CFLAGS"
     LDFLAGS="$GLIB_LIBS"
 
     # libblockdev-kbd
     AC_MSG_CHECKING([libblockdev-kbd presence])
-    AC_TRY_COMPILE([#include <kbd.h>], [],
+    AC_TRY_COMPILE([#include <blockdev/kbd.h>], [],
                    [AC_MSG_RESULT([yes])
                     have_kbd=yes],
                    [AC_MSG_RESULT([no])
                     have_kbd=no])
 
-    KBD_CFLAGS="-I/usr/include/blockdev"
+    KBD_CFLAGS=""
     KBD_LIBS="-lbd_kbd"
 
     if test "x$have_kbd" = "xno"; then
@@ -362,12 +362,12 @@ if test "x$enable_zram" = "xyes" \
     AC_SUBST([KBD_CFLAGS])
     AC_SUBST([KBD_LIBS])
 
-    CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
+    CFLAGS="$GLIB_CFLAGS"
     LDFLAGS="$GLIB_LIBS"
 
     # libblockdev-swap
     AC_MSG_CHECKING([libblockdev-swap presence])
-    AC_TRY_COMPILE([#include <swap.h>], [],
+    AC_TRY_COMPILE([#include <blockdev/swap.h>], [],
                    [AC_MSG_RESULT([yes])
                    have_swap=yes],
                    [AC_MSG_RESULT([no])
@@ -376,7 +376,7 @@ if test "x$enable_zram" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    SWAP_CFLAGS="-I/usr/include/blockdev"
+    SWAP_CFLAGS=""
     SWAP_LIBS="-lbd_swap"
 
     if test "x$have_swap" = "xno"; then
@@ -429,12 +429,12 @@ if test "x$enable_bcache" = "xyes" \
     # libblockdev
     SAVE_CFLAGS=$CFLAGS
     SAVE_LDFLAGS=$LDFLAGS
-    CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
+    CFLAGS="$GLIB_CFLAGS"
     LDFLAGS="$GLIB_LIBS"
 
     # libblockdev-kbd
     AC_MSG_CHECKING([libblockdev-kbd presence])
-    AC_TRY_COMPILE([#include <kbd.h>], [],
+    AC_TRY_COMPILE([#include <blockdev/kbd.h>], [],
                    [AC_MSG_RESULT([yes])
                     have_bcache=yes],
                    [AC_MSG_RESULT([no])
@@ -442,7 +442,7 @@ if test "x$enable_bcache" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    BCACHE_CFLAGS="-I/usr/include/blockdev"
+    BCACHE_CFLAGS=""
     BCACHE_LIBS="-lbd_kbd"
 
     if test "x$have_bcache" = "xno"; then
@@ -458,7 +458,7 @@ have_libblockdev_part=no
 have_libblockdev_part_spec=0
 SAVE_CFLAGS=$CFLAGS
 SAVE_LDFLAGS=$LDFLAGS
-CFLAGS="$GLIB_CFLAGS -I/usr/include/blockdev"
+CFLAGS="$GLIB_CFLAGS"
 LDFLAGS="$GLIB_LIBS"
 AC_CHECK_HEADERS(
         [blockdev/part.h],
@@ -470,7 +470,7 @@ AC_CHECK_HEADERS(
                          [Define if libbd_part is available])
                have_libblockdev_part=yes
                have_libblockdev_part_spec=1
-               PART_CFLAGS="-I/usr/include/blockdev"
+               PART_CFLAGS=""
                PART_LDFLAGS="-lbd_part"],
               have_libblockdev_part=no
               have_libblockdev_part_spec=0)

--- a/modules/bcache/udiskslinuxmanagerbcache.c
+++ b/modules/bcache/udiskslinuxmanagerbcache.c
@@ -217,7 +217,7 @@ handle_bcache_create (UDisksManagerBcache    *object,
                                      N_("Authentication is required to create bcache device."),
                                      invocation);
 
-  if (! bd_kbd_bcache_create (backing_dev, cache_dev, &bcache, &error))
+  if (! bd_kbd_bcache_create (backing_dev, cache_dev, NULL, &bcache, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/btrfs/udiskslinuxfilesystembtrfs.c
+++ b/modules/btrfs/udiskslinuxfilesystembtrfs.c
@@ -57,8 +57,8 @@ struct _UDisksLinuxFilesystemBTRFSClass {
   UDisksFilesystemBTRFSSkeletonClass parent_class;
 };
 
-typedef gboolean (*btrfs_subvolume_func)(gchar *mount_point, gchar *name, GError **error);
-typedef gboolean (*btrfs_device_func)(gchar *mountpoint, gchar *device, GError **error);
+typedef gboolean (*btrfs_subvolume_func)(const gchar *mount_point, const gchar *name, const BDExtraArg **extra, GError **error);
+typedef gboolean (*btrfs_device_func)(const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
 
 enum
 {
@@ -420,7 +420,7 @@ btrfs_subvolume_perform_action (UDisksFilesystemBTRFS *fs_btrfs,
     }
 
   /* Add/remove the subvolume. */
-  if (! subvolume_action (mount_point, name, &error))
+  if (! subvolume_action (mount_point, name, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -480,7 +480,7 @@ btrfs_device_perform_action (UDisksFilesystemBTRFS *fs_btrfs,
   device = g_strdup (arg_device);
 
   /* Add/remove the device to/from the volume. */
-  if (! device_action (mount_point, device, &error))
+  if (! device_action (mount_point, device, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -668,7 +668,7 @@ handle_create_snapshot(UDisksFilesystemBTRFS  *fs_btrfs,
   dest = g_build_path (G_DIR_SEPARATOR_S, mount_point, arg_dest, NULL);
 
   /* Create the snapshot. */
-  if (! bd_btrfs_create_snapshot (source, dest, arg_ro, &error))
+  if (! bd_btrfs_create_snapshot (source, dest, arg_ro, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -723,7 +723,7 @@ handle_repair (UDisksFilesystemBTRFS *fs_btrfs,
     }
 
   /* Check and repair. */
-  if (! bd_btrfs_repair (dev_file, &error))
+  if (! bd_btrfs_repair (dev_file, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;
@@ -776,7 +776,7 @@ handle_resize (UDisksFilesystemBTRFS *fs_btrfs,
     }
 
   /* Resize the volume. */
-  if (! bd_btrfs_resize (mount_point, arg_size, &error))
+  if (! bd_btrfs_resize (mount_point, arg_size, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/btrfs/udiskslinuxmanagerbtrfs.c
+++ b/modules/btrfs/udiskslinuxmanagerbtrfs.c
@@ -206,11 +206,7 @@ handle_create_volume (UDisksManagerBTRFS    *manager,
                                      N_("Authentication is required to create a new volume"),
                                      invocation);
 
-  if (! bd_btrfs_create_volume ((gchar **) arg_devices,
-                                (gchar *) arg_label,
-                                (gchar *) arg_data_level,
-                                (gchar *) arg_md_level,
-                                &error))
+  if (! bd_btrfs_create_volume ((const gchar const **)arg_devices, arg_label, arg_data_level, arg_md_level, NULL, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/zram/udiskslinuxblockzram.c
+++ b/modules/zram/udiskslinuxblockzram.c
@@ -258,7 +258,7 @@ zram_device_activate (UDisksBlockZRAM       *zramblock_,
 
   dev_file = udisks_linux_block_object_get_device_file (object);
 
-  if (! bd_swap_mkswap (dev_file, label, &error))
+  if (! bd_swap_mkswap (dev_file, label, NULL, &error))
   {
     g_dbus_method_invocation_take_error (invocation, error);
     goto out;


### PR DESCRIPTION
These changes allow storaged to build and run with libblockdev 2.0. Please note that the tests are doomed to fail now because the testers don't have libblockdev 2.0 installed (otherwise tests on the branches that don't have changes in this PR would fail).