### PR TITLE
Use libblockdev as a library not just the plugins

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,10 @@ PKG_CHECK_MODULES(GMODULE, [gmodule-2.0])
 AC_SUBST(GMODULE_CFLAGS)
 AC_SUBST(GMODULE_LIBS)
 
+PKG_CHECK_MODULES(BLOCKDEV, [blockdev >= 2.0])
+AC_SUBST(BLOCKDEV_CFLAGS)
+AC_SUBST(BLOCKDEV_LIBS)
+
 PKG_CHECK_MODULES(POLKIT_GOBJECT_1, [polkit-gobject-1 >= 0.102])
 AC_SUBST(POLKIT_GOBJECT_1_CFLAGS)
 AC_SUBST(POLKIT_GOBJECT_1_LIBS)
@@ -319,15 +323,9 @@ if test "x$enable_btrfs" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    BTRFS_CFLAGS=""
-    BTRFS_LIBS="-lbd_btrfs"
-
     if test "x$have_btrfs" = "xno"; then
       AC_MSG_ERROR([BTRFS support requested but header or library not found])
     fi
-
-    AC_SUBST([BTRFS_CFLAGS])
-    AC_SUBST([BTRFS_LIBS])
 fi
 AM_CONDITIONAL(HAVE_BTRFS, [test "x$have_btrfs" = "xyes"])
 
@@ -352,15 +350,9 @@ if test "x$enable_zram" = "xyes" \
                    [AC_MSG_RESULT([no])
                     have_kbd=no])
 
-    KBD_CFLAGS=""
-    KBD_LIBS="-lbd_kbd"
-
     if test "x$have_kbd" = "xno"; then
       AC_MSG_ERROR([KBD support requested but header or library not found])
     fi
-
-    AC_SUBST([KBD_CFLAGS])
-    AC_SUBST([KBD_LIBS])
 
     CFLAGS="$GLIB_CFLAGS"
     LDFLAGS="$GLIB_LIBS"
@@ -376,15 +368,9 @@ if test "x$enable_zram" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    SWAP_CFLAGS=""
-    SWAP_LIBS="-lbd_swap"
-
     if test "x$have_swap" = "xno"; then
       AC_MSG_ERROR([SWAP support requested but header or library not found])
     fi
-
-    AC_SUBST([SWAP_CFLAGS])
-    AC_SUBST([SWAP_LIBS])
 
     have_zram="yes"
 
@@ -442,15 +428,9 @@ if test "x$enable_bcache" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    BCACHE_CFLAGS=""
-    BCACHE_LIBS="-lbd_kbd"
-
     if test "x$have_bcache" = "xno"; then
       AC_MSG_ERROR([Bcache support requested but header or library not found])
     fi
-
-    AC_SUBST([BCACHE_CFLAGS])
-    AC_SUBST([BCACHE_LIBS])
 fi
 AM_CONDITIONAL(HAVE_BCACHE, [test "x$have_bcache" = "xyes"])
 
@@ -469,17 +449,13 @@ AC_CHECK_HEADERS(
               [AC_DEFINE(HAVE_LIBBLOCKDEV_PART, 1,
                          [Define if libbd_part is available])
                have_libblockdev_part=yes
-               have_libblockdev_part_spec=1
-               PART_CFLAGS=""
-               PART_LDFLAGS="-lbd_part"],
+               have_libblockdev_part_spec=1],
               have_libblockdev_part=no
               have_libblockdev_part_spec=0)
         ],
         have_libblockdev_part=no)
 AM_CONDITIONAL(HAVE_LIBBLOCKDEV_PART, [test "x$have_libblockdev_part" = "xyes"])
 AC_SUBST([have_libblockdev_part_spec])
-AC_SUBST([PART_CFLAGS])
-AC_SUBST([PART_LDFLAGS])
 CFLAGS=$SAVE_CFLAGS
 LDFLAGS=$SAVE_LDFLAGS
 
@@ -499,15 +475,9 @@ AC_TRY_COMPILE([#include <swap.h>], [],
 CFLAGS=$SAVE_CFLAGS
 LDFLAGS=$SAVE_LDFLAGS
 
-SWAP_CFLAGS="-I/usr/include/blockdev"
-SWAP_LIBS="-lbd_swap"
-
 if test "x$have_swap" = "xno"; then
   AC_MSG_ERROR([SWAP support requested but header or library not found])
 fi
-
-AC_SUBST([SWAP_CFLAGS])
-AC_SUBST([SWAP_LIBS])
 
 # Internationalization
 #

--- a/modules/bcache/Makefile.am
+++ b/modules/bcache/Makefile.am
@@ -24,6 +24,7 @@ CPPFLAGS =                                                                    \
 	$(GLIB_CFLAGS)                                                        \
 	$(GIO_CFLAGS)                                                         \
 	$(GUDEV_CFLAGS)                                                       \
+	$(BLOCKDEV_CFLAGS)                                                    \
 	$(WARN_CFLAGS)                                                        \
 	$(NULL)
 
@@ -82,7 +83,7 @@ libudisks2_bcache_la_CFLAGS =                                                 \
 	$(GIO_CFLAGS)                                                         \
 	$(GUDEV_CFLAGS)                                                       \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                            \
-	$(BCACHE_CFLAGS)                                                      \
+	$(BLOCKDEV_CFLAGS)                                                    \
 	$(NULL)
 
 libudisks2_bcache_la_LDFLAGS =                                                \
@@ -99,7 +100,7 @@ libudisks2_bcache_la_LIBADD =                                                 \
 	$(GIO_LIBS)                                                           \
 	$(GUDEV_LIBS)                                                         \
 	$(POLKIT_GOBJECT_1_LIBS)                                              \
-	$(BCACHE_LIBS)                                                        \
+	$(BLOCKDEV_LIBS)                                                      \
 	$(NULL)
 
 # ------------------------------------------------------------------------------

--- a/modules/bcache/udisksbcachemoduleiface.c
+++ b/modules/bcache/udisksbcachemoduleiface.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <blockdev/blockdev.h>
+
 #include <modules/udisksmoduleiface.h>
 
 #include <udisks/udisks-generated.h>
@@ -43,6 +45,25 @@ udisks_module_id (void)
 gpointer
 udisks_module_init (UDisksDaemon *daemon)
 {
+  gboolean ret = FALSE;
+  GError *error = NULL;
+
+  /* NULL means no specific so_name (implementation) */
+  BDPluginSpec kbd_plugin = {BD_PLUGIN_KBD, NULL};
+  BDPluginSpec *plugins[] = {&kbd_plugin, NULL};
+
+  if (!bd_is_plugin_available (BD_PLUGIN_KBD))
+    {
+      ret = bd_reinit (plugins, NULL, FALSE, &error);
+      if (!ret)
+        {
+          udisks_error ("Error initializing the kbd libblockdev plugin: %s (%s, %d)",
+                        error->message, g_quark_to_string (error->domain), error->code);
+          g_clear_error (error);
+          /* XXX: can do nothing more here even though we know the module will be unusable! */
+        }
+    }
+
   return udisks_bcache_state_new (daemon);
 }
 

--- a/modules/btrfs/Makefile.am
+++ b/modules/btrfs/Makefile.am
@@ -24,6 +24,7 @@ CPPFLAGS =                                                                     \
 	$(GLIB_CFLAGS)                                                         \
 	$(GIO_CFLAGS)                                                          \
 	$(GUDEV_CFLAGS)                                                        \
+	$(BLOCKDEV_CFLAGS)                                                     \
 	$(WARN_CFLAGS)                                                         \
 	$(NULL)
 
@@ -82,7 +83,7 @@ libudisks2_btrfs_la_CFLAGS =                                                   \
 	$(GIO_CFLAGS)                                                          \
 	$(GUDEV_CFLAGS)                                                        \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
-	$(BTRFS_CFLAGS)                                                        \
+	$(BLOCKDEV_CFLAGS)                                                     \
 	$(NULL)
 
 libudisks2_btrfs_la_LDFLAGS =                                                  \
@@ -99,7 +100,7 @@ libudisks2_btrfs_la_LIBADD =                                                   \
 	$(GIO_LIBS)                                                            \
 	$(GUDEV_LIBS)                                                          \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
-	$(BTRFS_LIBS)                                                          \
+	$(BLOCKDEV_LIBS)                                                       \
 	$(NULL)
 
 # ------------------------------------------------------------------------------

--- a/modules/btrfs/udisksbtrfsmoduleiface.c
+++ b/modules/btrfs/udisksbtrfsmoduleiface.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <blockdev/blockdev.h>
+
 #include <modules/udisksmoduleiface.h>
 
 #include <udisks/udisks-generated.h>
@@ -45,6 +47,25 @@ udisks_module_id (void)
 gpointer
 udisks_module_init (UDisksDaemon *daemon)
 {
+  gboolean ret = FALSE;
+  GError *error = NULL;
+
+  /* NULL means no specific so_name (implementation) */
+  BDPluginSpec btrfs_plugin = {BD_PLUGIN_BTRFS, NULL};
+  BDPluginSpec *plugins[] = {&btrfs_plugin, NULL};
+
+  if (!bd_is_plugin_available (BD_PLUGIN_BTRFS))
+    {
+      ret = bd_reinit (plugins, NULL, FALSE, &error);
+      if (!ret)
+        {
+          udisks_error ("Error initializing the btrfs libblockdev plugin: %s (%s, %d)",
+                        error->message, g_quark_to_string (error->domain), error->code);
+          g_clear_error (error);
+          /* XXX: can do nothing more here even though we know the module will be unusable! */
+        }
+    }
+
   return udisks_btrfs_state_new (daemon);
 }
 

--- a/modules/zram/Makefile.am
+++ b/modules/zram/Makefile.am
@@ -32,6 +32,7 @@ CPPFLAGS =                                                                     \
 	$(GLIB_CFLAGS)                                                         \
 	$(GIO_CFLAGS)                                                          \
 	$(GUDEV_CFLAGS)                                                        \
+	$(BLOCKDEV_CFLAGS)                                                     \
 	$(WARN_CFLAGS)                                                         \
 	$(NULL)
 
@@ -90,8 +91,7 @@ libudisks2_zram_la_CFLAGS =                                                    \
 	$(GIO_CFLAGS)                                                          \
 	$(GUDEV_CFLAGS)                                                        \
 	$(POLKIT_GOBJECT_1_CFLAGS)                                             \
-	$(KBD_CFLAGS)                                                          \
-	$(SWAP_CFLAGS)                                                         \
+	$(BLOCKDEV_CFLAGS)                                                     \
 	$(NULL)
 
 libudisks2_zram_la_LDFLAGS =                                                   \
@@ -108,8 +108,7 @@ libudisks2_zram_la_LIBADD =                                                    \
 	$(GIO_LIBS)                                                            \
 	$(GUDEV_LIBS)                                                          \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
-	$(KBD_LIBS)                                                            \
-	$(SWAP_LIBS)                                                           \
+	$(BLOCKDEV_LIBS)                                                       \
 	$(NULL)
 
 # ------------------------------------------------------------------------------

--- a/modules/zram/udiskszrammoduleiface.c
+++ b/modules/zram/udiskszrammoduleiface.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <blockdev/blockdev.h>
+
 #include <modules/udisksmoduleiface.h>
 
 #include <udisks/udisks-generated.h>
@@ -43,6 +45,26 @@ udisks_module_id (void)
 gpointer
 udisks_module_init (UDisksDaemon *daemon)
 {
+  gboolean ret = FALSE;
+  GError *error = NULL;
+
+  /* NULL means no specific so_name (implementation) */
+  BDPluginSpec kbd_plugin = {BD_PLUGIN_KBD, NULL};
+  BDPluginSpec swap_plugin = {BD_PLUGIN_SWAP, NULL};
+  BDPluginSpec *plugins[] = {&kbd_plugin, &swap_plugin, NULL};
+
+  if (!bd_is_plugin_available (BD_PLUGIN_KBD) || !bd_is_plugin_available (BD_PLUGIN_SWAP))
+    {
+      ret = bd_reinit (plugins, NULL, FALSE, &error);
+      if (!ret)
+        {
+          udisks_error ("Error initializing the kbd and swap libblockdev plugins: %s (%s, %d)",
+                        error->message, g_quark_to_string (error->domain), error->code);
+          g_clear_error (error);
+          /* XXX: can do nothing more here even though we know the module will be unusable! */
+        }
+    }
+
   return udisks_zram_state_new (daemon);
 }
 

--- a/packaging/storaged.spec.in
+++ b/packaging/storaged.spec.in
@@ -4,6 +4,7 @@
 %global systemd_version                 208
 %global libatasmart_version             0.17
 %global dbus_version                    1.4.0
+%global libblockdev_version             2.1
 %global with_gtk_doc                    1
 %global with_libblockdev_part           @have_libblockdev_part_spec@
 %global libblockdev_version             2.1
@@ -37,6 +38,7 @@ BuildRequires: libacl-devel
 BuildRequires: chrpath
 BuildRequires: gtk-doc
 BuildRequires: intltool
+BuildRequires: libblockdev-devel  >= %{libblockdev_version}
 BuildRequires: libblockdev-part-devel  >= %{libblockdev_version}
 BuildRequires: libblockdev-btrfs-devel >= %{libblockdev_version}
 BuildRequires: libblockdev-kbd-devel   >= %{libblockdev_version}
@@ -63,8 +65,6 @@ Requires: cryptsetup-luks
 Requires: eject
 # For MD-RAID
 Requires: mdadm
-# For swap
-Requires: libblockdev-swap
 
 Requires: lib%{name}%{?_isa} = %{version}-%{release}
 
@@ -139,8 +139,7 @@ Summary: Module for Bcache
 Group: System Environment/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
-Requires: libblockdev-kbd
-BuildRequires: libblockdev-kbd-devel
+Requires: libblockdev-kbd >= %{libblockdev_version}
 
 %description -n %{name}-bcache
 This package contains module for Bcache configuration.
@@ -150,8 +149,7 @@ Summary: Module for BTRFS
 Group: System Environment/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
-Requires: libblockdev-btrfs
-BuildRequires: libblockdev-btrfs-devel
+Requires: libblockdev-btrfs >= %{libblockdev_version}
 
 %description -n %{name}-btrfs
 This package contains module for BTRFS configuration.
@@ -175,8 +173,6 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
 Requires: libblockdev-kbd
 Requires: libblockdev-swap
-BuildRequires: libblockdev-kbd-devel
-BuildRequires: libblockdev-swap-devel
 
 %description -n %{name}-zram
 This package contains module for ZRAM configuration.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,7 @@ CPPFLAGS =                                                                     \
 	$(GLIB_CFLAGS)                                                         \
 	$(GIO_CFLAGS)                                                          \
 	$(GMODULE_CFLAGS)                                                      \
+	$(BLOCKDEV_CFLAGS)													   \
 	$(WARN_CFLAGS)                                                         \
 	$(NULL)
 
@@ -109,6 +110,7 @@ libudisks_daemon_la_LIBADD =                                                   \
 	$(GIO_LIBS)                                                            \
 	$(GMODULE_LIBS)                                                        \
 	$(GUDEV_LIBS)                                                          \
+	$(BLOCKDEV_LIBS)                                                          \
 	$(LIBATASMART_LIBS)                                                    \
 	$(POLKIT_GOBJECT_1_LIBS)                                               \
 	$(ACL_LIBS)                                                            \
@@ -135,6 +137,7 @@ udisksd_LDADD =                                                                \
 	$(GLIB_LIBS)                                                           \
 	$(GIO_LIBS)                                                            \
 	$(GMODULE_LIBS)                                                        \
+	$(BLOCKDEV_LIBS)                                                       \
 	libudisks-daemon.la                                                    \
 	$(NULL)
 


### PR DESCRIPTION
This intentionally  has changes from https://github.com/storaged-project/storaged/pull/128 merged because it builds on them. Please review only the last patch, the rest will be merged before this.

Also please note that this PR is for the *master-libblockdev* branch. I think we can leave the *master* branch as it is and only merge these changes there when *master-libblockdev* gets merged to master.