### PR TITLE
Replace g_error_free() with g_clear_error()

### DIFF
--- a/modules/bcache/udiskslinuxblockbcache.c
+++ b/modules/bcache/udiskslinuxblockbcache.c
@@ -161,7 +161,7 @@ udisks_linux_block_bcache_get_daemon (UDisksLinuxBlockBcache *block)
   else
     {
       udisks_error ("%s", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   return daemon;
@@ -215,7 +215,7 @@ out:
   if (stats)
     bd_kbd_bcache_stats_free (stats);
   if (error)
-    g_error_free (error);
+    g_clear_error (&error);
   g_free (dev_file);
 
   return rval;

--- a/modules/btrfs/udiskslinuxfilesystembtrfs.c
+++ b/modules/btrfs/udiskslinuxfilesystembtrfs.c
@@ -204,7 +204,7 @@ udisks_linux_filesystem_btrfs_get_daemon (UDisksLinuxFilesystemBTRFS *l_fs_btrfs
   else
     {
       udisks_error ("%s", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   return daemon;
@@ -258,7 +258,7 @@ out:
   if (btrfs_info)
     bd_btrfs_filesystem_info_free (btrfs_info);
   if (error)
-    g_error_free (error);
+    g_clear_error (&error);
   g_free ((gpointer) dev_file);
 
   return rval;

--- a/modules/lvm2/udiskslinuxlogicalvolume.c
+++ b/modules/lvm2/udiskslinuxlogicalvolume.c
@@ -397,7 +397,7 @@ handle_delete (UDisksLogicalVolume   *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -532,7 +532,7 @@ handle_rename (UDisksLogicalVolume   *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -632,7 +632,7 @@ handle_resize (UDisksLogicalVolume   *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -765,7 +765,7 @@ handle_activate (UDisksLogicalVolume *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -865,7 +865,7 @@ handle_deactivate (UDisksLogicalVolume   *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -953,7 +953,7 @@ handle_create_snapshot (UDisksLogicalVolume   *_volume,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/modules/lvm2/udiskslinuxvolumegroup.c
+++ b/modules/lvm2/udiskslinuxvolumegroup.c
@@ -299,7 +299,7 @@ handle_delete (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -406,7 +406,7 @@ handle_rename (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -509,7 +509,7 @@ handle_add_device (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -628,7 +628,7 @@ handle_remove_device (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -758,7 +758,7 @@ handle_empty_device (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -900,7 +900,7 @@ handle_create_plain_volume (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1000,7 +1000,7 @@ handle_create_thin_pool_volume (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1118,7 +1118,7 @@ handle_create_thin_volume (UDisksVolumeGroup     *_group,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/modules/lvm2/udiskslvm2daemonutil.c
+++ b/modules/lvm2/udiskslvm2daemonutil.c
@@ -284,7 +284,7 @@ variant_reader_watch_child (GPid     pid,
   if (!g_spawn_check_exit_status (status, &error))
     {
       data->callback (pid, NULL, error, data->user_data);
-      g_error_free (error);
+      g_clear_error (&error);
       g_byte_array_free (data->output, TRUE);
     }
   else
@@ -356,7 +356,7 @@ udisks_daemon_util_lvm2_spawn_for_variant (const gchar        **argv,
                                  &error))
     {
       callback (0, NULL, error, user_data);
-      g_error_free (error);
+      g_clear_error (&error);
       return 0;
     }
 

--- a/modules/zram/udiskslinuxblockzram.c
+++ b/modules/zram/udiskslinuxblockzram.c
@@ -162,7 +162,7 @@ udisks_linux_block_zram_get_daemon (UDisksLinuxBlockZRAM *zramblock)
   else
     {
       udisks_error ("%s", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   return daemon;
@@ -219,7 +219,7 @@ out:
   if (zram_info)
     bd_kbd_zram_stats_free (zram_info);
   if (error)
-    g_error_free (error);
+    g_clear_error (&error);
   g_free (dev_file);
 
   return rval;

--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,7 @@ main (int    argc,
   if (!g_option_context_parse (opt_context, &argc, &argv, &error))
     {
       g_printerr ("Error parsing options: %s\n", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskscrypttabmonitor.c
+++ b/src/udiskscrypttabmonitor.c
@@ -283,7 +283,7 @@ udisks_crypttab_monitor_constructed (GObject *object)
     {
       udisks_error ("Error monitoring /etc/crypttab: %s (%s, %d)",
                     error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
   else
     {
@@ -374,7 +374,7 @@ udisks_crypttab_monitor_ensure (UDisksCrypttabMonitor *monitor)
           udisks_warning ("Error opening /etc/crypttab file: %s (%s, %d)",
                           error->message, g_quark_to_string (error->domain), error->code);
         }
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -250,7 +250,7 @@ udisks_daemon_constructed (GObject *object)
     {
       udisks_error ("Error initializing polkit authority: %s (%s, %d)",
                     error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   daemon->object_manager = g_dbus_object_manager_server_new ("/org/freedesktop/UDisks2");

--- a/src/udisksdaemonutil.c
+++ b/src/udisksdaemonutil.c
@@ -732,7 +732,7 @@ udisks_daemon_util_check_authorization_sync_with_error (UDisksDaemon           *
           /* assume polkit authority is not available (e.g. could be the service
            * manager returning org.freedesktop.systemd1.Masked)
            */
-          g_error_free (sub_error);
+          g_clear_error (&sub_error);
           ret = check_authorization_no_polkit (daemon, object, action_id, options, message, invocation, error);
         }
       else
@@ -744,7 +744,7 @@ udisks_daemon_util_check_authorization_sync_with_error (UDisksDaemon           *
                        sub_error->message,
                        g_quark_to_string (sub_error->domain),
                        sub_error->code);
-          g_error_free (sub_error);
+          g_clear_error (&sub_error);
         }
       goto out;
     }
@@ -840,7 +840,7 @@ udisks_daemon_util_get_caller_uid_sync (UDisksDaemon            *daemon,
                    local_error->message,
                    g_quark_to_string (local_error->domain),
                    local_error->code);
-      g_error_free (local_error);
+      g_clear_error (&local_error);
       goto out;
     }
 
@@ -943,7 +943,7 @@ udisks_daemon_util_get_caller_pid_sync (UDisksDaemon            *daemon,
                    local_error->message,
                    g_quark_to_string (local_error->domain),
                    local_error->code);
-      g_error_free (local_error);
+      g_clear_error (&local_error);
       goto out;
     }
 

--- a/src/udisksfstabmonitor.c
+++ b/src/udisksfstabmonitor.c
@@ -284,7 +284,7 @@ udisks_fstab_monitor_constructed (GObject *object)
     {
       udisks_error ("Error monitoring /etc/fstab: %s (%s, %d)",
                     error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
   else
     {

--- a/src/udiskslinuxblock.c
+++ b/src/udiskslinuxblock.c
@@ -763,7 +763,7 @@ update_configuration (UDisksLinuxBlock  *block,
     {
       udisks_warning ("Error loading configuration: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       configuration = g_variant_new ("a(sa{sv})", NULL);
     }
   udisks_block_set_configuration (UDISKS_BLOCK (block), configuration);
@@ -881,7 +881,7 @@ udisks_linux_find_child_configuration (UDisksDaemon *daemon,
     {
       udisks_warning ("Error loading configuration: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       res = g_variant_new ("a(sa{sv})", NULL);
     }
   g_free (needle);
@@ -2693,7 +2693,7 @@ handle_format_failure (GDBusMethodInvocation *invocation,
   if (invocation != NULL)
     g_dbus_method_invocation_take_error (invocation, error);
   else
-    g_error_free (error);
+    g_clear_error (&error);
 }
 
 void
@@ -2805,7 +2805,7 @@ udisks_linux_block_handle_format (UDisksBlock             *block,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, &caller_gid, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxdrive.c
+++ b/src/udiskslinuxdrive.c
@@ -994,7 +994,7 @@ handle_eject (UDisksDrive           *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1398,7 +1398,7 @@ handle_power_off (UDisksDrive           *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -1179,7 +1179,7 @@ handle_smart_selftest_start (UDisksDriveAta        *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1383,7 +1383,7 @@ handle_pm_standby (UDisksDriveAta        *_drive,
                                                  &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1517,7 +1517,7 @@ handle_pm_wakeup (UDisksDriveAta        *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -2315,7 +2315,7 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -2344,7 +2344,7 @@ handle_security_erase_unit (UDisksDriveAta        *_drive,
   if (!udisks_linux_drive_ata_secure_erase_sync (drive, caller_uid, enhanced, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -2408,7 +2408,7 @@ handle_smart_set_enabled (UDisksDriveAta        *_drive,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxdriveobject.c
+++ b/src/udiskslinuxdriveobject.c
@@ -1029,7 +1029,7 @@ udisks_linux_drive_object_housekeeping (UDisksLinuxDriveObject  *object,
             {
               udisks_info ("Drive %s is in a sleep state",
                            g_dbus_object_get_object_path (G_DBUS_OBJECT (object)));
-              g_error_free (local_error);
+              g_clear_error (&local_error);
             }
           else if (nowakeup && (local_error->domain == UDISKS_ERROR &&
                                 local_error->code == UDISKS_ERROR_DEVICE_BUSY))
@@ -1037,7 +1037,7 @@ udisks_linux_drive_object_housekeeping (UDisksLinuxDriveObject  *object,
               /* typically because a "secure erase" operation is pending */
               udisks_info ("Drive %s is busy",
                            g_dbus_object_get_object_path (G_DBUS_OBJECT (object)));
-              g_error_free (local_error);
+              g_clear_error (&local_error);
             }
           else
             {

--- a/src/udiskslinuxencrypted.c
+++ b/src/udiskslinuxencrypted.c
@@ -327,7 +327,7 @@ handle_unlock (UDisksEncrypted        *encrypted,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -708,7 +708,7 @@ handle_change_passphrase (UDisksEncrypted        *encrypted,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -216,7 +216,7 @@ is_in_filesystem_file (const gchar *filesystems_file,
                       error->message,
                       g_quark_to_string (error->domain),
                       error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1247,7 +1247,7 @@ handle_mount (UDisksFilesystem      *filesystem,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1397,7 +1397,7 @@ handle_mount (UDisksFilesystem      *filesystem,
   if (fs_type_to_use == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1412,7 +1412,7 @@ handle_mount (UDisksFilesystem      *filesystem,
   if (mount_options_to_use == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1460,7 +1460,7 @@ handle_mount (UDisksFilesystem      *filesystem,
   if (mount_point_to_use == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1625,7 +1625,7 @@ handle_unmount (UDisksFilesystem      *filesystem,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1878,7 +1878,7 @@ handle_set_label (UDisksFilesystem      *filesystem,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxloop.c
+++ b/src/udiskslinuxloop.c
@@ -148,7 +148,7 @@ udisks_linux_loop_update (UDisksLinuxLoop        *loop,
                               g_quark_to_string (error->domain),
                               error->code);
             }
-          g_error_free (error);
+          g_clear_error (&error);
           udisks_loop_set_backing_file (UDISKS_LOOP (loop), "");
         }
       else
@@ -218,7 +218,7 @@ handle_delete (UDisksLoop            *loop,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -404,7 +404,7 @@ handle_set_autoclear (UDisksLoop             *loop,
   if (!udisks_daemon_util_get_caller_uid_sync (daemon, invocation, NULL, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxmanager.c
+++ b/src/udiskslinuxmanager.c
@@ -327,7 +327,7 @@ handle_loop_setup (UDisksManager          *object,
   if (!udisks_daemon_util_get_caller_uid_sync (manager->daemon, invocation, NULL /* GCancellable */, &caller_uid, NULL, NULL, &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -694,7 +694,7 @@ handle_start (UDisksMDRaid           *_mdraid,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1067,7 +1067,7 @@ handle_remove_device (UDisksMDRaid           *_mdraid,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1270,7 +1270,7 @@ handle_add_device (UDisksMDRaid           *_mdraid,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1409,7 +1409,7 @@ handle_set_bitmap_location (UDisksMDRaid           *_mdraid,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1531,7 +1531,7 @@ handle_request_sync_action (UDisksMDRaid           *_mdraid,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxpartition.c
+++ b/src/udiskslinuxpartition.c
@@ -260,7 +260,7 @@ handle_set_flags (UDisksPartition       *partition,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -441,7 +441,7 @@ handle_set_name (UDisksPartition       *partition,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -770,7 +770,7 @@ handle_set_type (UDisksPartition       *partition,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -874,7 +874,7 @@ handle_delete (UDisksPartition       *partition,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -381,7 +381,7 @@ udisks_linux_partition_table_handle_create_partition (UDisksPartitionTable   *ta
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udiskslinuxprovider.c
+++ b/src/udiskslinuxprovider.c
@@ -773,7 +773,7 @@ perform_initial_housekeeping_for_drive (GTask           *task,
       udisks_warning ("Error performing initial housekeeping for drive %s: %s (%s, %d)",
                       g_dbus_object_get_object_path (G_DBUS_OBJECT (object)),
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 }
 
@@ -1312,7 +1312,7 @@ housekeeping_all_drives (UDisksLinuxProvider *provider,
           udisks_warning ("Error performing housekeeping for drive %s: %s (%s, %d)",
                           g_dbus_object_get_object_path (G_DBUS_OBJECT (object)),
                           error->message, g_quark_to_string (error->domain), error->code);
-          g_error_free (error);
+          g_clear_error (&error);
         }
     }
 
@@ -1355,7 +1355,7 @@ housekeeping_all_modules (UDisksLinuxProvider *provider,
           udisks_warning ("Error performing housekeeping for module object %s: %s (%s, %d)",
                           g_dbus_object_get_object_path (G_DBUS_OBJECT (object)),
                           error->message, g_quark_to_string (error->domain), error->code);
-          g_error_free (error);
+          g_clear_error (&error);
         }
     }
 

--- a/src/udiskslinuxswapspace.c
+++ b/src/udiskslinuxswapspace.c
@@ -184,7 +184,7 @@ handle_start (UDisksSwapspace        *swapspace,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -271,7 +271,7 @@ handle_stop (UDisksSwapspace        *swapspace,
                                                &error))
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udisksmodulemanager.c
+++ b/src/udisksmodulemanager.c
@@ -314,7 +314,7 @@ udisks_module_manager_get_modules_list (UDisksModuleManager *manager)
   if (! dir)
     {
       udisks_warning ("Error loading modules: %s", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
       g_free (module_dir);
       return NULL;
     }

--- a/src/udisksmountmonitor.c
+++ b/src/udisksmountmonitor.c
@@ -313,7 +313,7 @@ udisks_mount_monitor_constructed (GObject *object)
   else
     {
       g_error ("No /proc/self/mountinfo file: %s", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   error = NULL;
@@ -332,7 +332,7 @@ udisks_mount_monitor_constructed (GObject *object)
           udisks_warning ("Error opening /proc/swaps file: %s (%s, %d)",
                           error->message, g_quark_to_string (error->domain), error->code);
         }
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   if (G_OBJECT_CLASS (udisks_mount_monitor_parent_class)->constructed != NULL)
@@ -613,7 +613,7 @@ udisks_mount_monitor_ensure (UDisksMountMonitor *monitor)
     {
       udisks_warning ("Error getting mounts: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   error = NULL;
@@ -621,7 +621,7 @@ udisks_mount_monitor_ensure (UDisksMountMonitor *monitor)
     {
       udisks_warning ("Error getting swaps: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   monitor->have_data = TRUE;

--- a/src/udisksspawnedjob.c
+++ b/src/udisksspawnedjob.c
@@ -229,7 +229,7 @@ emit_completed_with_error_in_idle_cb (gpointer user_data)
                  data->job->child_stderr,  /* standard_error */
                  &ret);
   g_object_unref (data->job);
-  g_error_free (data->error);
+  g_clear_error (&(data->error));
   g_free (data);
   return FALSE;
 }
@@ -268,7 +268,7 @@ on_cancelled (GCancellable *cancellable,
   error = NULL;
   g_warn_if_fail (g_cancellable_set_error_if_cancelled (cancellable, &error));
   emit_completed_with_error_in_idle (job, error);
-  g_error_free (error);
+  g_clear_error (&error);
 }
 
 static gboolean
@@ -439,7 +439,7 @@ udisks_spawned_job_constructed (GObject *object)
   if (g_cancellable_set_error_if_cancelled (udisks_base_job_get_cancellable (UDISKS_BASE_JOB (job)), &error))
     {
       emit_completed_with_error_in_idle (job, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -458,7 +458,7 @@ udisks_spawned_job_constructed (GObject *object)
                       "Error parsing command-line `%s': ",
                       job->command_line);
       emit_completed_with_error_in_idle (job, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -471,7 +471,7 @@ udisks_spawned_job_constructed (GObject *object)
           g_set_error(&error, G_IO_ERROR, G_IO_ERROR_FAILED,
                       "No password record for uid %d: %m\n", (gint) job->run_as_euid);
           emit_completed_with_error_in_idle (job, error);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
       job->real_egid = pw->pw_gid;
@@ -482,7 +482,7 @@ udisks_spawned_job_constructed (GObject *object)
           g_set_error(&error, G_IO_ERROR, G_IO_ERROR_FAILED,
                       "No password record for uid %d: %m\n", (gint) job->run_as_uid);
           emit_completed_with_error_in_idle (job, error);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
       job->real_gid = pw->pw_gid;
@@ -507,7 +507,7 @@ udisks_spawned_job_constructed (GObject *object)
                       "Error spawning command-line `%s': ",
                       job->command_line);
       emit_completed_with_error_in_idle (job, error);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udisksstate.c
+++ b/src/udisksstate.c
@@ -786,7 +786,7 @@ udisks_state_check_mounted_fs (UDisksState *state,
     {
       udisks_warning ("Error getting mounted-fs: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -824,7 +824,7 @@ udisks_state_check_mounted_fs (UDisksState *state,
                           error->message,
                           g_quark_to_string (error->domain),
                           error->code);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
     }
@@ -879,7 +879,7 @@ udisks_state_add_mounted_fs (UDisksState    *state,
     {
       udisks_warning ("Error getting mounted-fs: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -943,7 +943,7 @@ udisks_state_add_mounted_fs (UDisksState    *state,
     {
       udisks_warning ("Error setting mounted-fs: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -990,7 +990,7 @@ udisks_state_find_mounted_fs (UDisksState   *state,
     {
       udisks_warning ("Error getting mounted-fs: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1253,7 +1253,7 @@ udisks_state_check_unlocked_luks (UDisksState *state,
     {
       udisks_warning ("Error getting unlocked-luks: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1291,7 +1291,7 @@ udisks_state_check_unlocked_luks (UDisksState *state,
                           error->message,
                           g_quark_to_string (error->domain),
                           error->code);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
     }
@@ -1346,7 +1346,7 @@ udisks_state_add_unlocked_luks (UDisksState  *state,
     {
       udisks_warning ("Error getting unlocked-luks: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1410,7 +1410,7 @@ udisks_state_add_unlocked_luks (UDisksState  *state,
     {
       udisks_warning ("Error setting unlocked-luks: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1455,7 +1455,7 @@ udisks_state_find_unlocked_luks (UDisksState   *state,
     {
       udisks_warning ("Error getting unlocked-luks: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1632,7 +1632,7 @@ udisks_state_check_loop (UDisksState *state,
     {
       udisks_warning ("Error getting loop: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1670,7 +1670,7 @@ udisks_state_check_loop (UDisksState *state,
                           error->message,
                           g_quark_to_string (error->domain),
                           error->code);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
     }
@@ -1726,7 +1726,7 @@ udisks_state_add_loop (UDisksState   *state,
     {
       udisks_warning ("Error getting loop: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1789,7 +1789,7 @@ udisks_state_add_loop (UDisksState   *state,
     {
       udisks_warning ("Error setting loop: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1834,7 +1834,7 @@ udisks_state_has_loop (UDisksState   *state,
     {
       udisks_warning ("Error getting loop: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -1978,7 +1978,7 @@ udisks_state_check_mdraid (UDisksState *state,
     {
       udisks_warning ("Error getting mdraid: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -2016,7 +2016,7 @@ udisks_state_check_mdraid (UDisksState *state,
                           error->message,
                           g_quark_to_string (error->domain),
                           error->code);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
     }
@@ -2064,7 +2064,7 @@ udisks_state_add_mdraid (UDisksState   *state,
     {
       udisks_warning ("Error getting mdraid: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -2119,7 +2119,7 @@ udisks_state_add_mdraid (UDisksState   *state,
     {
       udisks_warning ("Error setting mdraid: %s (%s, %d)",
                       error->message, g_quark_to_string (error->domain), error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/src/udisksthreadedjob.c
+++ b/src/udisksthreadedjob.c
@@ -98,7 +98,7 @@ udisks_threaded_job_finalize (GObject *object)
   UDisksThreadedJob *job = UDISKS_THREADED_JOB (object);
 
   if (job->job_error != NULL)
-    g_error_free (job->job_error);
+    g_clear_error (&(job->job_error));
 
   if (job->user_data_free_func != NULL)
     job->user_data_free_func (job->user_data);

--- a/tools/udisksctl.c
+++ b/tools/udisksctl.c
@@ -85,7 +85,7 @@ setup_local_polkit_agent (void)
                   error->message,
                   g_quark_to_string (error->domain),
                   error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
   local_agent_handle = polkit_agent_listener_register (local_polkit_agent,
@@ -100,7 +100,7 @@ setup_local_polkit_agent (void)
                   error->message,
                   g_quark_to_string (error->domain),
                   error->code);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -819,13 +819,13 @@ handle_command_mount_unmount (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto try_again;
             }
           g_printerr ("Error mounting %s: %s\n",
                       udisks_block_get_device (block),
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           g_object_unref (object);
           goto out;
         }
@@ -848,13 +848,13 @@ handle_command_mount_unmount (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto try_again;
             }
           g_printerr ("Error unmounting %s: %s\n",
                       udisks_block_get_device (block),
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           g_object_unref (object);
           goto out;
         }
@@ -1265,13 +1265,13 @@ handle_command_unlock_lock (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto try_again;
             }
           g_printerr ("Error unlocking %s: %s\n",
                       udisks_block_get_device (block),
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           g_object_unref (object);
           goto out;
         }
@@ -1299,13 +1299,13 @@ handle_command_unlock_lock (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto try_again;
             }
           g_printerr ("Error locking %s: %s\n",
                       udisks_block_get_device (block),
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           g_object_unref (object);
           goto out;
         }
@@ -1639,14 +1639,14 @@ handle_command_loop (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto setup_try_again;
             }
           g_object_unref (fd_list);
           g_printerr ("Error setting up loop device for %s: %s\n",
                       opt_loop_file,
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
       g_object_unref (fd_list);
@@ -1705,13 +1705,13 @@ handle_command_loop (gint        *argc,
               error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
               setup_local_polkit_agent ())
             {
-              g_error_free (error);
+              g_clear_error (&error);
               goto delete_try_again;
             }
           g_printerr ("Error deleting loop device %s: %s\n",
                       udisks_block_get_device (udisks_object_peek_block (object)),
                       error->message);
-          g_error_free (error);
+          g_clear_error (&error);
           goto out;
         }
       g_object_unref (object);
@@ -1984,7 +1984,7 @@ handle_command_smart_simulate (gint        *argc,
           error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
           setup_local_polkit_agent ())
         {
-          g_error_free (error);
+          g_clear_error (&error);
           goto try_again;
         }
       g_dbus_error_strip_remote_error (error);
@@ -2217,7 +2217,7 @@ handle_command_power_off (gint        *argc,
           error->code == UDISKS_ERROR_NOT_AUTHORIZED_CAN_OBTAIN &&
           setup_local_polkit_agent ())
         {
-          g_error_free (error);
+          g_clear_error (&error);
           goto try_again;
         }
       g_dbus_error_strip_remote_error (error);
@@ -3225,7 +3225,7 @@ main (int argc,
   if (client == NULL)
     {
       g_printerr ("Error connecting to the udisks daemon: %s\n", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/tools/umount-udisks.c
+++ b/tools/umount-udisks.c
@@ -103,7 +103,7 @@ main (int argc, char *argv[])
   if (client == NULL)
     {
       g_printerr ("Error connecting to the udisks daemon: %s\n", error->message);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 
@@ -129,7 +129,7 @@ main (int argc, char *argv[])
                                             &error))
     {
       g_printerr ("Error unmounting block device %u:%u: %s\n", major (block_device), minor (block_device), error->message);
-      g_error_free (error);
+      g_clear_error (&error);
       goto out;
     }
 

--- a/udisks/udisksclient.c
+++ b/udisks/udisksclient.c
@@ -131,7 +131,7 @@ udisks_client_finalize (GObject *object)
     g_source_destroy (client->changed_timeout_source);
 
   if (client->initialization_error != NULL)
-    g_error_free (client->initialization_error);
+    g_clear_error (&(client->initialization_error));
 
   /* might be NULL if failing early in the constructor */
   if (client->object_manager != NULL)


### PR DESCRIPTION
The difference between 'g_error_free (error)' and 'g_clear_error (&error)' is
that g_clear_error also sets 'error' to NULL. That may seem like a negligible
difference, but it is a huge one because many GLib (and other) functions have
the assert that 'error' is NULL as the first thing they do returning (NULL) if
the assert fails. So an error we may handle gracefully may cause follow-up
failures just because the variable is not set to NULL (indicating there has been
an unhandled error before).

There doesn't seem to be a single place where the above behaviour would be
desired so this patch replaces all g_error_free() calls by g_clear_error()
ones. It may not be necessary in some places, but I think a few extra
instructions for 'error = NULL' are worth the removal of potentially problematic
function calls from the codebase.