### PR TITLE
Tests for the Manager object/interface

### DIFF
--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -118,8 +118,8 @@ if __name__ == '__main__':
         daemon_bin_path = os.path.join(projdir, 'src', daemon_bin)
 
         # start the devel tree daemon
-        daemon = subprocess.Popen([daemon_bin_path, '--replace', '--uninstalled',
-            '--force-load-modules'], shell=False, stdout=daemon_log, stderr=daemon_log)
+        daemon = subprocess.Popen([daemon_bin_path, '--replace', '--uninstalled'],
+                                  shell=False, stdout=daemon_log, stderr=daemon_log)
         # give the daemon some time to initialize
         time.sleep(3)
         daemon.poll()

--- a/src/tests/dbus-tests/storagedtestcase.py
+++ b/src/tests/dbus-tests/storagedtestcase.py
@@ -107,6 +107,20 @@ class StoragedTestCase(unittest.TestCase):
         return (res.returncode, out)
 
     @classmethod
+    def ensure_modules_loaded(self):
+        manager_obj = self.get_object('/Manager')
+        manager = self.get_interface(manager_obj, '.Manager')
+        manager_intro = dbus.Interface(manager_obj, "org.freedesktop.DBus.Introspectable")
+        intro_data = manager_intro.Introspect()
+        modules_loaded = 'interface name="org.freedesktop.UDisks2.Manager.Bcache"' in intro_data
+
+        if not modules_loaded:
+            manager.EnableModules(dbus.Boolean(True))
+            intro_data = manager_intro.Introspect()
+            assert 'interface name="org.freedesktop.UDisks2.Manager.Bcache"' in intro_data
+
+
+    @classmethod
     def ay_to_str(self, ay):
         """Convert a bytearray (terminated with '\0') to a string"""
 

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -1,4 +1,3 @@
-import unittest
 import storagedtestcase
 import dbus
 import os
@@ -6,19 +5,31 @@ import os
 class StoragedBaseTest(storagedtestcase.StoragedTestCase):
     '''This is a base test suite'''
 
+    def setUp(self):
+        self.manager_obj = self.get_object('/Manager')
+
     def test_10_manager(self):
         '''Testing the manager object presence'''
-        manager = self.get_object('/Manager')
-        self.assertIsNotNone(manager)
-        version = self.get_property(manager, '.Manager', 'Version')
+        self.assertIsNotNone(self.manager_obj)
+        version = self.get_property(self.manager_obj, '.Manager', 'Version')
         self.assertIsNotNone(version)
-        manager.EnableModules(True, dbus_interface=self.iface_prefix + '.Manager')
 
+    def test_20_enable_modules(self):
+        manager = self.get_interface(self.manager_obj, '.Manager')
+        manager_intro = dbus.Interface(self.manager_obj, "org.freedesktop.DBus.Introspectable")
+        intro_data = manager_intro.Introspect()
+        modules_loaded = 'interface name="org.freedesktop.UDisks2.Manager.Bcache"' in intro_data
 
-    def test_20_device_presence(self):
+        if modules_loaded:
+            self.skipTest("Modules already loaded, nothing to test")
+        else:
+            manager.EnableModules(dbus.Boolean(True))
+            intro_data = manager_intro.Introspect()
+            self.assertIn('interface name="org.freedesktop.UDisks2.Manager.Bcache"', intro_data)
+
+    def test_80_device_presence(self):
         '''Test the debug devices are present on the bus'''
         for d in self.vdevs:
             dev_obj = self.get_object("/block_devices/%s" % os.path.basename(d))
             self.assertIsNotNone(dev_obj)
             self.assertTrue(os.path.exists(d))
-

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -27,6 +27,11 @@ class StoragedBaseTest(storagedtestcase.StoragedTestCase):
             intro_data = manager_intro.Introspect()
             self.assertIn('interface name="org.freedesktop.UDisks2.Manager.Bcache"', intro_data)
 
+    def test_30_supported_filesystems(self):
+        fss = self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems')
+        self.assertEqual({str(s) for s in fss},
+                         {'nilfs2', 'btrfs', 'swap', 'ext3', 'udf', 'xfs', 'minix', 'ext2', 'ext4', 'f2fs', 'reiserfs', 'ntfs', 'vfat', 'exfat'})
+
     def test_80_device_presence(self):
         '''Test the debug devices are present on the bus'''
         for d in self.vdevs:


### PR DESCRIPTION
The goal of this PR is to provide missing tests for the ``Manager`` object/interface API. The ``MDRaidCreate`` method is covered by the PR with the MD RAID tests (https://github.com/storaged-project/storaged/pull/138). The ``Version`` property is covered by a test in *test_10_basic.py*. And since extra methods provided by modules should be tested in the modules' tests, the missing pieces here are:

- [x] the ``EnableModules`` method (used in some other tests, but only to load the modules, not unload)
- [x] the ``SupportedFilesystems`` property

Please ignore the commits up to "Merge pull request #1 from vojtechtrefny/master-tests_commons2" which are part of the PR with test improvements (https://github.com/storaged-project/storaged/pull/139), or ideally, review that PR. :)