### PR TITLE
Add 'redhat_rpm_config' to BuildRequires

### DIFF
--- a/packaging/storaged.spec.in
+++ b/packaging/storaged.spec.in
@@ -37,6 +37,7 @@ BuildRequires: libacl-devel
 BuildRequires: chrpath
 BuildRequires: gtk-doc
 BuildRequires: intltool
+BuildRequires: redhat-rpm-config
 BuildRequires: libblockdev-part-devel  >= %{libblockdev_version}
 BuildRequires: libblockdev-btrfs-devel >= %{libblockdev_version}
 BuildRequires: libblockdev-kbd-devel   >= %{libblockdev_version}


### PR DESCRIPTION
Provides '/usr/lib/rpm/redhat/redhat-hardened-cc1' needed for build.