### PR TITLE
Give MD RAID some time to actually change its state

### DIFF
--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -199,6 +199,7 @@ class RAID0TestCase(RAIDLevel):
         # stop the array
         array.Stop(self.no_options, dbus_interface=self.iface_prefix + '.MDRaid')
 
+        time.sleep(1)
         dbus_running = self.get_property(array, '.MDRaid', 'Running')
         self.assertFalse(dbus_running)
 
@@ -208,6 +209,7 @@ class RAID0TestCase(RAIDLevel):
         # start the array
         array.Start(self.no_options, dbus_interface=self.iface_prefix + '.MDRaid')
 
+        time.sleep(1)
         dbus_running = self.get_property(array, '.MDRaid', 'Running')
         self.assertTrue(dbus_running)
 


### PR DESCRIPTION
When we start/stop the array, it takes a small amount of time for the change to
propagate to the DBus object's 'Running' property. This is not too great, but we
don't want this to make our tests failing in 9 of 10 runs.