### PR TITLE
Add dbus tests for job objects

### DIFF
--- a/src/tests/dbus-tests/safe_dbus.py
+++ b/src/tests/dbus-tests/safe_dbus.py
@@ -1,0 +1,203 @@
+#
+# Copyright (C) 2013-2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
+#
+# This module was taken from the sources of the Anaconda installer.
+#
+
+"""Module providing thread-safe and mainloop-safe DBus operations."""
+
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gio", "2.0")
+
+from gi.repository import GLib, Gio
+
+import os
+
+DEFAULT_DBUS_TIMEOUT = 100 * 1000
+DBUS_PROPS_IFACE = "org.freedesktop.DBus.Properties"
+DBUS_INTRO_IFACE = "org.freedesktop.DBus.Introspectable"
+
+
+class SafeDBusError(Exception):
+    """Class for exceptions defined in this module."""
+
+    pass
+
+
+class DBusCallError(SafeDBusError):
+    """Class for the errors related to calling methods over DBus."""
+
+    pass
+
+
+class DBusPropertyError(DBusCallError):
+    """Class for the errors related to getting property values over DBus."""
+
+    pass
+
+
+def get_new_system_connection():
+    """Return a new connection to the system bus."""
+
+    return Gio.DBusConnection.new_for_address_sync(
+        Gio.dbus_address_get_for_bus_sync(Gio.BusType.SYSTEM, None),
+        Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT |
+        Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
+        None, None)
+
+
+def get_new_session_connection():
+    """
+    Get a connection handle for the per-user-login-session message bus.
+
+    !!! RUN THIS EARLY !!! like, before any other threads start. Connections to
+    the session bus must be made with the effective UID of the login user,
+    which in live installs is not the UID of anaconda. This means we need to
+    call seteuid in this method, and doing that after threads have started will
+    probably do something weird.
+
+    Live installs use consolehelper to run as root, which sets the original
+    UID in $USERHELPER_UID.
+
+    :return: the session connection handle
+    :rtype: Gio.DBusConnection
+    :raise DBusCallError: if some DBus related error appears
+    :raise OSError: if unable to set the effective UID
+    """
+
+    old_euid = None
+    if "USERHELPER_UID" in os.environ:
+        old_euid = os.geteuid()
+        os.seteuid(int(os.environ["USERHELPER_UID"]))
+
+    try:
+        connection = Gio.DBusConnection.new_for_address_sync(
+            Gio.dbus_address_get_for_bus_sync(Gio.BusType.SESSION, None),
+            Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT |
+            Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
+            None, None)
+    except GLib.GError as gerr:
+        raise DBusCallError("Unable to connect to session bus: %s", gerr)
+    finally:
+        if old_euid is not None:
+            os.seteuid(old_euid)
+
+    if connection.is_closed():
+        raise DBusCallError("Connection is closed")
+
+    return connection
+
+
+def call_sync(service, obj_path, iface, method, args,
+              connection=None, timeout=DEFAULT_DBUS_TIMEOUT):
+    """
+    Safely call a given method on a given object of a given service over DBus
+    passing given arguments. If a connection is given, it is used, otherwise a
+    new connection is established. Safely means that it is a synchronous,
+    thread-safe call not using any main loop.
+
+    :param service: DBus service to use
+    :type service: str
+    :param obj_path: object path of the object to call method on
+    :type obj_path: str
+    :param iface: interface to use
+    :type iface: str
+    :param method: name of the method to call
+    :type method: str
+    :param args: arguments to pass to the method
+    :type args: GVariant
+    :param connection: connection to use (if None, a new connection is
+                       established)
+    :type connection: Gio.DBusConnection
+    :param timeout: timeout for calls (in ms)
+    :type connection: int
+    :return: unpacked value returned by the method
+    :rtype: tuple with elements that depend on the method
+    :raise DBusCallError: if some DBus related error appears
+
+    """
+
+    if not connection:
+        try:
+            connection = get_new_system_connection()
+        except GLib.GError as gerr:
+            raise DBusCallError("Unable to connect to system bus: %s", gerr)
+
+    if connection.is_closed():
+        raise DBusCallError("Connection is closed")
+
+    try:
+        ret = connection.call_sync(service, obj_path, iface, method, args,
+                                   None, Gio.DBusCallFlags.NONE,
+                                   timeout, None)
+    except GLib.GError as gerr:
+        msg = "Failed to call %s method on %s with %s arguments: %s" % \
+              (method, obj_path, args, gerr.message)  # pylint: disable=no-member
+        raise DBusCallError(msg)
+
+    if ret is None:
+        ret = ret.unpack()
+    return ret
+
+
+def get_property_sync(service, obj_path, iface, prop_name,
+                      connection=None):
+    """
+    Get value of a given property of a given object provided by a given service.
+
+    :param service: DBus service to use
+    :type service: str
+    :param obj_path: object path
+    :type obj_path: str
+    :param iface: interface to use
+    :type iface: str
+    :param prop_name: name of the property
+    :type prop_name: str
+    :param connection: connection to use (if None, a new connection is
+                       established)
+    :type connection: Gio.DBusConnection
+    :return: unpacked value of the property
+    :rtype: tuple with elements that depend on the type of the property
+    :raise DBusCallError: when the internal dbus_call_safe_sync invocation
+                          raises an exception
+    :raise DBusPropertyError: when the given object doesn't have the given
+                              property
+
+    """
+
+    args = GLib.Variant('(ss)', (iface, prop_name))
+    ret = call_sync(service, obj_path, DBUS_PROPS_IFACE, "Get", args,
+                    connection)
+    if ret is None:
+        msg = "No value for the %s object's property %s" % (obj_path, prop_name)
+        raise DBusPropertyError(msg)
+
+    return ret
+
+
+def check_object_available(service, obj_path, iface=None):
+    intro_data = call_sync(service, obj_path, DBUS_INTRO_IFACE, "Introspect", None)
+    node_info = Gio.DBusNodeInfo.new_for_xml(intro_data.unpack()[0])
+    if not iface:
+        # just check if any interface is available (there are none for
+        # non-existing objects)
+        return bool(node_info.interfaces)
+    else:
+        return any(intface.name == iface for intface in node_info.interfaces)

--- a/src/tests/dbus-tests/test_job.py
+++ b/src/tests/dbus-tests/test_job.py
@@ -1,0 +1,129 @@
+import datetime
+import os
+import time
+import threading
+
+import gi
+gi.require_version('GLib', '2.0')
+from gi.repository import GLib
+
+import safe_dbus
+import storagedtestcase
+
+
+class StoragedJobTest(storagedtestcase.StoragedTestCase):
+    '''This is a basic test suite for job objects and interface'''
+
+    def setUp(self):
+        self.job = None
+        self.exception = None
+
+    def _get_objects(self):
+        objects = safe_dbus.call_sync(self.iface_prefix,
+                                      self.path_prefix,
+                                      'org.freedesktop.DBus.ObjectManager',
+                                      'GetManagedObjects',
+                                      None)
+        return objects
+
+    def _secure_erase(self, devname):
+        try:
+            safe_dbus.call_sync(self.iface_prefix,
+                                self.path_prefix + '/block_devices/' + devname,
+                                self.iface_prefix + '.Block',
+                                'Format',
+                                GLib.Variant('(sa{sv})', ('empty', {'erase': GLib.Variant("s", 'zero')})))
+        except Exception as e:
+            self.exception = e
+
+    def _wait_for_job_thread(self, operation, device_path):
+        t = threading.currentThread()
+
+        while getattr(t, "run", True):
+            objects = self._get_objects()
+
+            jobs = {k: v for (k, v) in objects[0].items() if '/jobs/' in k}
+
+            for job_path, properties in jobs.items():
+                if properties[self.iface_prefix + '.Job']['Operation'] == operation and \
+                   properties[self.iface_prefix + '.Job']['Objects'] == [device_path]:
+                    self.job = (job_path, properties)
+                    return
+
+            time.sleep(0.1)
+
+    def test_job(self):
+        '''Test basic Job functionality and properties'''
+
+        disk_name = os.path.basename(self.vdevs[0])
+        obj_path = self.path_prefix + '/block_devices/' + disk_name
+
+        start_time = datetime.datetime.now().timestamp()
+
+        watch_thread = threading.Thread(target=self._wait_for_job_thread, args=('format-erase', obj_path))
+        watch_thread.start()
+
+        erase_thread = threading.Thread(target=self._secure_erase, args=(disk_name,))
+        erase_thread.start()
+        erase_thread.join()
+
+        # unexpected exception occured in erase thread -- raise it
+        if self.exception is not None:
+            raise self.exception
+
+        # erase thread finished, stop job searching
+        watch_thread.run = False
+        watch_thread.join()
+
+        # we should have the job dict now
+        self.assertIsNotNone(self.job)
+
+        # get all the properties from the dict
+        properties = self.job[1][self.iface_prefix + '.Job']
+
+        _ret, disk_size = self.run_command('lsblk -b -no SIZE %s' % self.vdevs[0])  # get size of the device
+        self.assertEqual(properties['Bytes'], int(disk_size))
+
+        self.assertEqual(properties['StartedByUID'], os.getuid())
+
+        # test start time -- should be less than ~0.5s after thread started
+        # (dbus property is in micro seconds)
+        self.assertLessEqual(abs(properties['StartTime'] - start_time * 10**6), 0.5 * 10**6)
+
+        self.assertTrue(properties['Cancelable'])
+
+    def test_cancel(self):
+        '''Test if it's possible to cancel the Job'''
+
+        disk_name = os.path.basename(self.vdevs[0])
+        obj_path = self.path_prefix + '/block_devices/' + disk_name
+
+        watch_thread = threading.Thread(target=self._wait_for_job_thread, args=('format-erase', obj_path))
+        watch_thread.start()
+
+        erase_thread = threading.Thread(target=self._secure_erase, args=(disk_name,))
+        erase_thread.start()
+
+        # watch thread should end first -- we need the job before erase finishes
+        watch_thread.join()
+        self.assertIsNotNone(self.job)
+
+        job_path = self.job[0]
+
+        # cancel the job
+        safe_dbus.call_sync(self.iface_prefix,
+                            job_path,
+                            self.iface_prefix + '.Job',
+                            'Cancel',
+                            GLib.Variant('(a{sv})', ({},)))
+
+        # job shouldn't be in managed objects
+        objects = self._get_objects()
+        self.assertNotIn(job_path, objects[0].items())
+
+        erase_thread.join()
+
+        # erase thread should raise exception (it's stored in self.exception)
+        self.assertIsNotNone(self.exception)
+        self.assertTrue(isinstance(self.exception, safe_dbus.DBusCallError))
+        self.assertIn('Error erasing device: Job was canceled', str(self.exception))


### PR DESCRIPTION
'safe_dbus' module allows us to use dbus from multiple threads.
This part is copied from Anaconda installer codebase.