### PR TITLE
DBus tests: Use checks that automatically wait for property update

### DIFF
--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -12,7 +12,7 @@ class StoragedBaseTest(storagedtestcase.StoragedTestCase):
         '''Testing the manager object presence'''
         self.assertIsNotNone(self.manager_obj)
         version = self.get_property(self.manager_obj, '.Manager', 'Version')
-        self.assertIsNotNone(version)
+        version.assertIsNotNone()
 
     def test_20_enable_modules(self):
         manager = self.get_interface(self.manager_obj, '.Manager')
@@ -29,7 +29,7 @@ class StoragedBaseTest(storagedtestcase.StoragedTestCase):
 
     def test_30_supported_filesystems(self):
         fss = self.get_property(self.manager_obj, '.Manager', 'SupportedFilesystems')
-        self.assertEqual({str(s) for s in fss},
+        self.assertEqual({str(s) for s in fss.value},
                          {'nilfs2', 'btrfs', 'swap', 'ext3', 'udf', 'xfs', 'minix', 'ext2', 'ext4', 'f2fs', 'reiserfs', 'ntfs', 'vfat', 'exfat'})
 
     def test_80_device_presence(self):

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -78,7 +78,8 @@ class StoragedDriveTest(storagedtestcase.StoragedTestCase):
 
         # validate that configration property has changed
         conf_value = self.get_property(self.cd_drive, '.Drive', 'Configuration')
-        self.assertEqual(str(conf_value['ata-pm-standby']), '286')
+        conf_value.assertIsNotNone()
+        self.assertEqual(str(conf_value.value['ata-pm-standby']), '286')
 
     def test_40_properties(self):
         ''' Test of Drive properties values '''
@@ -119,12 +120,12 @@ class StoragedDriveTest(storagedtestcase.StoragedTestCase):
 
         for prop_name, expected_val in expected_prop_vals.items():
             actual_val = self.get_property(self.cd_drive, '.Drive', prop_name)
-            self.assertEqual(expected_val, actual_val)
+            actual_val.assertEqual(expected_val)
 
         # timeDetected and TimeMediaDetected has the same value and SortKey value
         # is derived from it
         timedetected = self.get_property(self.cd_drive, '.Drive', 'TimeDetected')
         timemediadetected = self.get_property(self.cd_drive, '.Drive', 'TimeMediaDetected')
-        self.assertEqual(timedetected, timemediadetected)
+        self.assertEqual(timedetected.value, timemediadetected.value)
         sortkey = self.get_property(self.cd_drive, '.Drive', 'SortKey')
-        self.assertEqual(sortkey, '01hotplug/%s' % timedetected)
+        sortkey.assertEqual('01hotplug/%s' % timedetected.value)

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -27,10 +27,10 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         disk.Format('xfs', self.no_options, dbus_interface=self.iface_prefix + '.Block')
 
         usage = self.get_property(disk, '.Block', 'IdUsage')
-        self.assertEqual(usage, 'filesystem')
+        usage.assertEqual('filesystem')
 
         fstype = self.get_property(disk, '.Block', 'IdType')
-        self.assertEqual(fstype, 'xfs')
+        fstype.assertEqual('xfs')
 
         _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_fstype, 'xfs')
@@ -40,10 +40,10 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
 
         # check if the disk is empty
         usage = self.get_property(disk, '.Block', 'IdUsage')
-        self.assertEqual(usage, '')
+        usage.assertEqual('')
 
         fstype = self.get_property(disk, '.Block', 'IdType')
-        self.assertEqual(fstype, '')
+        fstype.assertEqual('')
 
         _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_fstype, '')
@@ -107,38 +107,36 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
                                signature=dbus.Signature('sv'))
         disk.AddConfigurationItem(('fstab', conf), self.no_options,
                                   dbus_interface=self.iface_prefix + '.Block')
-        time.sleep(5)
 
         # get the configuration
         old_conf = self.get_property(disk, '.Block', 'Configuration')
-        self.assertIsNotNone(old_conf)
-        self.assertEqual(old_conf[0][1]['dir'], mnt)
-        self.assertEqual(old_conf[0][1]['type'], fstype)
-        self.assertEqual(old_conf[0][1]['opts'], opts)
-        self.assertEqual(old_conf[0][1]['passno'], 0)
-        self.assertEqual(old_conf[0][1]['freq'], 0)
+        old_conf.assertTrue()
+        self.assertEqual(old_conf.value[0][1]['dir'], mnt)
+        self.assertEqual(old_conf.value[0][1]['type'], fstype)
+        self.assertEqual(old_conf.value[0][1]['opts'], opts)
+        self.assertEqual(old_conf.value[0][1]['passno'], 0)
+        self.assertEqual(old_conf.value[0][1]['freq'], 0)
 
         # update the configuration
         new_opts = self.str_to_ay('defaults,noauto')
-        new_conf = copy.deepcopy(old_conf)
+        new_conf = copy.deepcopy(old_conf.value)
         new_conf[0][1]['opts'] = new_opts
 
-        disk.UpdateConfigurationItem((old_conf[0][0], old_conf[0][1]), (new_conf[0][0], new_conf[0][1]),
+        disk.UpdateConfigurationItem((old_conf.value[0][0], old_conf.value[0][1]), (new_conf[0][0], new_conf[0][1]),
                                      self.no_options, dbus_interface=self.iface_prefix + '.Block')
         time.sleep(5)
 
         # get the configuration after the update
         upd_conf = self.get_property(disk, '.Block', 'Configuration')
-        self.assertIsNotNone(upd_conf)
-        self.assertEqual(upd_conf[0][1]['opts'], new_opts)
+        upd_conf.assertTrue()
+        self.assertEqual(upd_conf.value[0][1]['opts'], new_opts)
 
         # remove the configuration
-        disk.RemoveConfigurationItem((upd_conf[0][0], upd_conf[0][1]),
+        disk.RemoveConfigurationItem((upd_conf.value[0][0], upd_conf.value[0][1]),
                                      self.no_options, dbus_interface=self.iface_prefix + '.Block')
-        time.sleep(5)
 
-        conf = disk.GetSecretConfiguration(self.no_options, dbus_interface=self.iface_prefix + '.Block')
-        self.assertEqual(len(conf), 0)
+        upd_conf = self.get_property(disk, '.Block', 'Configuration')
+        upd_conf.assertFalse()
 
     def test_configuration_crypttab(self):
 
@@ -162,12 +160,11 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         conf = dbus.Dictionary({'passphrase-contents': passwd,
                                 'options': opts}, signature=dbus.Signature('sv'))
         disk.AddConfigurationItem(('crypttab', conf), self.no_options, dbus_interface=self.iface_prefix + '.Block')
-        time.sleep(5)
 
         # get the configuration
         old_conf = self.get_property(disk, '.Block', 'Configuration')
-        self.assertIsNotNone(old_conf)
-        self.assertEqual(old_conf[0][1]['options'], opts)
+        old_conf.assertTrue()
+        self.assertEqual(old_conf.value[0][1]['options'], opts)
 
         # get the secret configuration (passphrase)
         sec_conf = disk.GetSecretConfiguration(self.no_options, dbus_interface=self.iface_prefix + '.Block')
@@ -185,16 +182,15 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
 
         # get the configuration after the update
         upd_conf = self.get_property(disk, '.Block', 'Configuration')
-        self.assertIsNotNone(upd_conf)
-        self.assertEqual(upd_conf[0][1]['options'], new_opts)
+        upd_conf.assertTrue()
+        self.assertEqual(upd_conf.value[0][1]['options'], new_opts)
 
         # remove the configuration
-        disk.RemoveConfigurationItem((upd_conf[0][0], upd_conf[0][1]),
+        disk.RemoveConfigurationItem((upd_conf.value[0][0], upd_conf.value[0][1]),
                                      self.no_options, dbus_interface=self.iface_prefix + '.Block')
-        time.sleep(5)
 
-        conf = disk.GetSecretConfiguration(self.no_options, dbus_interface=self.iface_prefix + '.Block')
-        self.assertEqual(len(conf), 0)
+        upd_conf = self.get_property(disk, '.Block', 'Configuration')
+        upd_conf.assertFalse()
 
     def test_rescan(self):
 

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -35,7 +35,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self._remove_format, disk)
 
         pttype = self.get_property(disk, '.PartitionTable', 'Type')
-        self.assertEqual(pttype, 'dos')
+        pttype.assertEqual('dos')
 
         part_type = '0x8e'  # 'Linux LVM' type, see https://en.wikipedia.org/wiki/Partition_type#PID_8Eh
 
@@ -51,13 +51,13 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check dbus properties
         size = self.get_property(part, '.Partition', 'Size')
-        self.assertEqual(size, 100 * 1024**2)
+        size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        self.assertEqual(offset, 2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
 
         dbus_type = self.get_property(part, '.Partition', 'Type')
-        self.assertEqual(dbus_type, part_type)
+        dbus_type.assertEqual(part_type)
 
         # check system values
         part_name = path.split('/')[-1]
@@ -77,11 +77,11 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         # check uuid and part number
         dbus_uuid = self.get_property(part, '.Partition', 'UUID')
         _ret, sys_uuid = self.run_command('lsblk -no PARTUUID /dev/%s' % part_name)
-        self.assertEqual(dbus_uuid, sys_uuid)
+        dbus_uuid.assertEqual(sys_uuid)
 
         dbus_num = self.get_property(part, '.Partition', 'Number')
         sys_num = int(self.read_file('%s/partition' % part_syspath))
-        self.assertEqual(dbus_num, sys_num)
+        dbus_num.assertEqual(sys_num)
 
     def test_create_extended_partition(self):
 
@@ -104,11 +104,11 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check dbus type (0x05, 0x0f, 0x85 are all exteded types, see https://en.wikipedia.org/wiki/Partition_type#PID_05h)
         dbus_pttype = self.get_property(ext_part, '.Partition', 'Type')
-        self.assertIn(dbus_pttype, ['0x05', '0x0f', '0x85'])
+        dbus_pttype.assertIn(['0x05', '0x0f', '0x85'])
 
         # check if its a 'container'
         dbus_cont = self.get_property(ext_part, '.Partition', 'IsContainer')
-        self.assertTrue(dbus_cont)
+        dbus_cont.assertTrue()
 
         # check system type
         part_name = str(ext_part.object_path).split('/')[-1]
@@ -127,7 +127,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check if its a 'contained'
         dbus_cont = self.get_property(log_part, '.Partition', 'IsContained')
-        self.assertTrue(dbus_cont)
+        dbus_cont.assertTrue()
 
     def test_create_gpt_partition(self):
         disk = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
@@ -136,7 +136,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         # create gpt partition table
         self._create_format(disk, 'gpt')
         pttype = self.get_property(disk, '.PartitionTable', 'Type')
-        self.assertEqual(pttype, 'gpt')
+        pttype.assertEqual('gpt')
 
         self.addCleanup(self._remove_format, disk)
 
@@ -155,16 +155,16 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check dbus properties
         size = self.get_property(part, '.Partition', 'Size')
-        self.assertEqual(size, 100 * 1024**2)
+        size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        self.assertEqual(offset, 2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
 
         dbus_name = self.get_property(part, '.Partition', 'Name')
-        self.assertEqual(dbus_name, gpt_name)
+        dbus_name.assertEqual(gpt_name)
 
         dbus_type = self.get_property(part, '.Partition', 'Type')
-        self.assertEqual(dbus_type, gpt_type)
+        dbus_type.assertEqual(gpt_type)
 
         # check system values
         part_name = path.split('/')[-1]
@@ -206,16 +206,16 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check dbus properties
         size = self.get_property(part, '.Partition', 'Size')
-        self.assertEqual(size, 100 * 1024**2)
+        size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        self.assertEqual(offset, 2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
 
         usage = self.get_property(part, '.Block', 'IdUsage')
-        self.assertEqual(usage, 'filesystem')
+        usage.assertEqual('filesystem')
 
         fstype = self.get_property(part, '.Block', 'IdType')
-        self.assertEqual(fstype, 'xfs')
+        fstype.assertEqual('xfs')
 
         # check system values
         part_name = path.split('/')[-1]
@@ -308,7 +308,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value on types
         dbus_flags = self.get_property(part, '.Partition', 'Flags')
-        self.assertEqual(dbus_flags, 128)
+        dbus_flags.assertEqual(128)
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
@@ -336,7 +336,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value on types
         dbus_type = self.get_property(part, '.Partition', 'Type')
-        self.assertEqual(dbus_type, home_guid)
+        dbus_type.assertEqual(home_guid)
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
@@ -364,7 +364,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value on types
         dbus_type = self.get_property(part, '.Partition', 'Type')
-        self.assertEqual(dbus_type, part_type)
+        dbus_type.assertEqual(part_type)
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
@@ -392,7 +392,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value on types
         dbus_name = self.get_property(part, '.Partition', 'Name')
-        self.assertEqual(dbus_name, 'test')
+        dbus_name.assertEqual('test')
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -29,23 +29,21 @@ class StoragedEncryptedTest(storagedtestcase.StoragedTestCase):
 
         # check dbus properties
         dbus_usage = self.get_property(disk, '.Block', 'IdUsage')
-        self.assertEqual(dbus_usage, 'crypto')
+        dbus_usage.assertEqual('crypto')
 
         dbus_type = self.get_property(disk, '.Block', 'IdType')
-        self.assertEqual(dbus_type, 'crypto_LUKS')
+        dbus_type.assertEqual('crypto_LUKS')
 
         device = self.get_property(disk, '.Block', 'Device')
-        device_path = "".join([str(i) for i in device[:-1]])  # device is an array of byte
-        self.assertEqual(device_path, self.vdevs[0])
-
-        dbus_uuid = self.get_property(disk, '.Block', 'IdUUID')
+        device.assertEqual(self.str_to_ay(self.vdevs[0]))  # device is an array of byte
 
         # check system values
         _ret, sys_type = self.run_command('lsblk -d -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_type, 'crypto_LUKS')
 
         _ret, sys_uuid = self.run_command('lsblk -d -no UUID %s' % self.vdevs[0])
-        self.assertEqual(sys_uuid, dbus_uuid)
+        dbus_uuid = self.get_property(disk, '.Block', 'IdUUID')
+        dbus_uuid.assertEqual(sys_uuid)
 
         # get the luks device
         _ret, dm_name = self.run_command('ls /sys/block/%s/holders/' % disk_name)
@@ -56,26 +54,24 @@ class StoragedEncryptedTest(storagedtestcase.StoragedTestCase):
 
         # check dbus properties
         dbus_usage = self.get_property(luks, '.Block', 'IdUsage')
-        self.assertEqual(dbus_usage, 'filesystem')
+        dbus_usage.assertEqual('filesystem')
 
         dbus_type = self.get_property(luks, '.Block', 'IdType')
-        self.assertEqual(dbus_type, 'xfs')
+        dbus_type.assertEqual('xfs')
 
         device = self.get_property(luks, '.Block', 'Device')
-        device_path = "".join(str(i) for i in device[:-1])  # device is an array of byte
-        self.assertEqual(device_path, '/dev/' + dm_name)
-
-        dbus_uuid = self.get_property(luks, '.Block', 'IdUUID')
+        device.assertEqual(self.str_to_ay('/dev/' + dm_name))  # device is an array of byte
 
         crypto_dev = self.get_property(luks, '.Block', 'CryptoBackingDevice')
-        self.assertEqual(crypto_dev, disk.object_path)
+        crypto_dev.assertEqual(disk.object_path)
 
         # check system values
         _ret, sys_type = self.run_command('lsblk -d -no FSTYPE /dev/%s' % dm_name)
         self.assertEqual(sys_type, 'xfs')
 
         _ret, sys_uuid = self.run_command('lsblk -d -no UUID /dev/%s' % dm_name)
-        self.assertEqual(sys_uuid, dbus_uuid)
+        bus_uuid = self.get_property(luks, '.Block', 'IdUUID')
+        bus_uuid.assertEqual(sys_uuid)
 
     def test_close_open(self):
         disk_name = os.path.basename(self.vdevs[0])

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -1,7 +1,6 @@
 import dbus
 import os
 import tempfile
-import time
 
 import storagedtestcase
 
@@ -38,10 +37,10 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
 
         # test dbus properties
         usage = self.get_property(disk, '.Block', 'IdUsage')
-        self.assertEqual(usage, 'filesystem')
+        usage.assertEqual('filesystem')
 
         fstype = self.get_property(disk, '.Block', 'IdType')
-        self.assertEqual(fstype, self._fs_name)
+        fstype.assertEqual(self._fs_name)
 
         # test system values
         _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
@@ -63,11 +62,10 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         d['label'] = label
         disk.Format(self._fs_name, d, dbus_interface=self.iface_prefix + '.Block')
         self.addCleanup(self._clean_format, disk)
-        time.sleep(1)
 
         # test dbus properties
         dbus_label = self.get_property(disk, '.Block', 'IdLabel')
-        self.assertEqual(dbus_label, label)
+        dbus_label.assertEqual(label)
 
         # test system values
         _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])
@@ -76,11 +74,10 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         # change the label
         label = 'AAAA' if self._fs_name == 'vfat' else 'aaaa'  # XXX storaged changes vfat labels to uppercase
         disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
-        time.sleep(1)
 
         # test dbus properties
         dbus_label = self.get_property(disk, '.Block', 'IdLabel')
-        self.assertEqual(dbus_label, label)
+        dbus_label.assertEqual(label)
 
         # test system values
         _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])
@@ -102,7 +99,7 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
 
         # not mounted
         mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
-        self.assertListEqual(mounts, [])
+        mounts.assertLen(0)
 
         # mount
         d = dbus.Dictionary(signature='sv')
@@ -113,8 +110,8 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
 
         # dbus mountpoint
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
-        self.assertEqual(len(dbus_mounts), 1)  # just one mountpoint
-        dbus_mnt = "".join(str(i) for i in dbus_mounts[0][:-1])  # mountpoints are arrays of bytes
+        dbus_mounts.assertLen(1)  # just one mountpoint
+        dbus_mnt = self.ay_to_str(dbus_mounts.value[0])  # mountpoints are arrays of bytes
         self.assertEqual(dbus_mnt, mnt_path)
 
         # system mountpoint
@@ -163,8 +160,8 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
 
         # dbus mountpoint
         dbus_mounts = self.get_property(disk, '.Filesystem', 'MountPoints')
-        self.assertEqual(len(dbus_mounts), 1)  # just one mountpoint
-        dbus_mnt = "".join([str(i) for i in dbus_mounts[0][:-1]])  # mountpoints are arrays of bytes
+        dbus_mounts.assertLen(1)  # just one mountpoint
+        dbus_mnt = self.ay_to_str(dbus_mounts.value[0])  # mountpoints are arrays of bytes
         self.assertEqual(dbus_mnt, tmp.name)
 
         # system mountpoint
@@ -184,11 +181,10 @@ class Ext2TestCase(StoragedFSTestCase):
     def _invalid_label(self, disk):
         label = 'a' * 17  # at most 16 characters, longer should be truncated
         disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
-        time.sleep(1)
 
         # test dbus properties
         dbus_label = self.get_property(disk, '.Block', 'IdLabel')
-        self.assertEqual(dbus_label, label[0:16])
+        dbus_label.assertEqual(label[0:16])
 
         # test system values
         _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])

--- a/src/tests/dbus-tests/test_90_swapspace.py
+++ b/src/tests/dbus-tests/test_90_swapspace.py
@@ -46,7 +46,7 @@ class StoragedSwapSpaceTest(storagedtestcase.StoragedTestCase):
         # Active property is now in undefined state
         iface.Start(self.no_options)
         active = self.get_property(iface, '.Swapspace', 'Active')
-        self.assertTrue(active)  # swap should be active
+        active.assertTrue()  # swap should be active
 
         code, result = self.run_command('swapon --show')
         self.assertEqual(code, 0)
@@ -57,4 +57,4 @@ class StoragedSwapSpaceTest(storagedtestcase.StoragedTestCase):
 
         iface.Stop(self.no_options)
         active = self.get_property(iface, '.Swapspace', 'Active')
-        self.assertFalse(active)  # swap shouldn't be active
+        active.assertFalse()  # swap shouldn't be active

--- a/src/tests/dbus-tests/test_drive_ata.py
+++ b/src/tests/dbus-tests/test_drive_ata.py
@@ -91,24 +91,24 @@ class StoragedDriveAtaTest(StoragedTestCase):
             drive_name = self.get_drive_name(self.get_device(disk))
             drive_obj = self.get_object("/drives/%s" % drive_name)
 
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "AamSupported"), props["aam"] != "Unavailable")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "AamEnabled"), props["aam"] == "Enabled")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "ApmSupported"), props["apm"] != "Unavailable")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "ApmEnabled"), props["apm"] == "Enabled")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "ReadLookaheadSupported"), props["lookahead"] != "Unavailable")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "ReadLookaheadEnabled"), props["lookahead"] == "Enabled")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "SmartSupported"), props["smart_supported"].startswith("Available"))
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "SmartEnabled"), props["smart_enabled"] == "Enabled")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "WriteCacheSupported"), props["wcache"] != "Unavailable")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "WriteCacheEnabled"), props["wcache"] == "Enabled")
-            self.assertEqual(self.get_property(drive_obj, ".Drive.Ata", "SmartFailing"), not props["healthy"])
+            self.get_property(drive_obj, ".Drive.Ata", "AamSupported").assertEqual(props["aam"] != "Unavailable")
+            self.get_property(drive_obj, ".Drive.Ata", "AamEnabled").assertEqual(props["aam"] == "Enabled")
+            self.get_property(drive_obj, ".Drive.Ata", "ApmSupported").assertEqual(props["apm"] != "Unavailable")
+            self.get_property(drive_obj, ".Drive.Ata", "ApmEnabled").assertEqual(props["apm"] == "Enabled")
+            self.get_property(drive_obj, ".Drive.Ata", "ReadLookaheadSupported").assertEqual(props["lookahead"] != "Unavailable")
+            self.get_property(drive_obj, ".Drive.Ata", "ReadLookaheadEnabled").assertEqual(props["lookahead"] == "Enabled")
+            self.get_property(drive_obj, ".Drive.Ata", "SmartSupported").assertEqual(props["smart_supported"].startswith("Available"))
+            self.get_property(drive_obj, ".Drive.Ata", "SmartEnabled").assertEqual(props["smart_enabled"] == "Enabled")
+            self.get_property(drive_obj, ".Drive.Ata", "WriteCacheSupported").assertEqual(props["wcache"] != "Unavailable")
+            self.get_property(drive_obj, ".Drive.Ata", "WriteCacheEnabled").assertEqual(props["wcache"] == "Enabled")
+            self.get_property(drive_obj, ".Drive.Ata", "SmartFailing").assertEqual(not props["healthy"])
 
             attrs = self.get_attrs(disk)
             # temperature has ID 190
             temp_attr = attrs.get(190)
             if temp_attr:
                 # reported in Kelvins (double) by API, but in Celsius degrees (int) by CLI
-                temp_c = self.get_property(drive_obj, ".Drive.Ata", "SmartTemperature") - 273
+                temp_c = self.get_property(drive_obj, ".Drive.Ata", "SmartTemperature").value - 273
                 # nineth field is the raw value
                 self.assertEqual(int(temp_c), int(temp_attr[8]))
 
@@ -118,7 +118,7 @@ class StoragedDriveAtaTest(StoragedTestCase):
                 # reported in seconds by API, but in hours by CLI
                 pwon_s = self.get_property(drive_obj, ".Drive.Ata", "SmartPowerOnSeconds")
                 # nineth field is the raw value
-                self.assertEqual(int(pwon_s / 3600), int(pwon_attr[8]))
+                self.assertEqual(int(pwon_s.value / 3600), int(pwon_attr[8]))
 
     @unittest.skipUnless(smart_supported, "No disks supporting S.M.A.R.T. available")
     def test_smart_get_attributes(self):
@@ -164,21 +164,21 @@ class StoragedDriveAtaTest(StoragedTestCase):
 
             # has to have a valid timestamp
             updated = self.get_property(drive_obj, ".Drive.Ata", "SmartUpdated")
-            self.assertTrue(updated)
-            orig = int(updated)
+            updated.assertTrue()
+            orig = int(updated.value)
 
             # wait at least a second so that the timestamp has a chance to change
             time.sleep(1)
             drive_ata.SmartUpdate(self.no_options)
             updated = self.get_property(drive_obj, ".Drive.Ata", "SmartUpdated")
-            self.assertTrue(updated)
-            self.assertGreater(int(updated), orig)
+            updated.assertTrue()
+            self.assertGreater(int(updated.value), orig)
 
-            orig = int(updated)
+            orig = int(updated.value)
             time.sleep(1)
             drive_ata.SmartUpdate(self.no_options)
             updated = self.get_property(drive_obj, ".Drive.Ata", "SmartUpdated")
-            self.assertTrue(updated)
-            self.assertGreater(int(updated), orig)
+            updated.assertTrue()
+            self.assertGreater(int(updated.value), orig)
             # the new timestamp should be less than 2 seconds off the previous one
-            self.assertLess(int(updated), orig+2)
+            self.assertLess(int(updated.value), orig+2)

--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -56,19 +56,19 @@ class StoragedLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.udev_settle()
         autoclear_flag = self.get_property(self.device, '.Loop', 'Autoclear')
         # property should be set now
-        self.assertTrue(autoclear_flag)
+        autoclear_flag.assertTrue()
         autoclear_flag = self.read_file(flag_file_name)
         self.assertEqual(autoclear_flag, '1\n')
 
     def test_30_backingfile(self):
         raw = self.get_property(self.device, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
     def test_40_setupbyuid(self):
         uid = self.get_property(self.device, '.Loop', 'SetupByUID')
-        self.assertEqual(uid, 0)  # uid should be 0 since device is not created by Udisks
+        uid.assertEqual(0)  # uid should be 0 since device is not created by Udisks
 
 class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
     """Unit tests for the loop-related methods of the Manager object"""
@@ -91,21 +91,20 @@ class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
         loop_dev_obj = self.get_object(loop_dev_obj_path)
-        time.sleep(0.5)
 
         # should use the right backing file
         raw = self.get_property(loop_dev_obj, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
         # should use the whole file
         size = self.get_property(loop_dev_obj, ".Block", "Size")
-        self.assertEqual(size, 10 * 1024**2)
+        size.assertEqual(10 * 1024**2)
 
         # should be writable
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
-        self.assertFalse(ro)
+        ro.assertFalse()
 
     def test_20_create_with_offset(self):
         opts = dbus.Dictionary({"offset": dbus.UInt64(4096)}, signature=dbus.Signature('sv'))
@@ -118,21 +117,20 @@ class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
         loop_dev_obj = self.get_object(loop_dev_obj_path)
-        time.sleep(0.5)
 
         # should use the right backing file
         raw = self.get_property(loop_dev_obj, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
         # should use the whole file except for the first 4096 bytes (offset)
         size = self.get_property(loop_dev_obj, ".Block", "Size")
-        self.assertEqual(size, 10 * 1024**2 - 4096)
+        size.assertEqual(10 * 1024**2 - 4096)
 
         # should be writable
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
-        self.assertFalse(ro)
+        ro.assertFalse()
 
     def test_30_create_with_offset_size(self):
         opts = dbus.Dictionary({"offset": dbus.UInt64(4096), "size": dbus.UInt64(4 * 1024**2)}, signature=dbus.Signature('sv'))
@@ -145,21 +143,20 @@ class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
         loop_dev_obj = self.get_object(loop_dev_obj_path)
-        time.sleep(0.5)
 
         # should use the right backing file
         raw = self.get_property(loop_dev_obj, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
         # should use just the space specified by the 'size' argument
         size = self.get_property(loop_dev_obj, ".Block", "Size")
-        self.assertEqual(size, 4 * 1024**2)
+        size.assertEqual(4 * 1024**2)
 
         # should be writable
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
-        self.assertFalse(ro)
+        ro.assertFalse()
 
     def test_40_create_read_only(self):
         opts = dbus.Dictionary({"read-only": dbus.Boolean(True)}, signature=dbus.Signature('sv'))
@@ -172,21 +169,20 @@ class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
         loop_dev_obj = self.get_object(loop_dev_obj_path)
-        time.sleep(0.5)
 
         # should use the right backing file
         raw = self.get_property(loop_dev_obj, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
         # should use the whole file
         size = self.get_property(loop_dev_obj, ".Block", "Size")
-        self.assertEqual(size, 10 * 1024**2)
+        size.assertEqual(10 * 1024**2)
 
         # should be read-only
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
-        self.assertTrue(ro)
+        ro.assertTrue()
 
     def test_50_create_no_part_scan(self):
         # create a partition on the file (future loop device)
@@ -205,21 +201,20 @@ class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self.run_command, "losetup -d /dev/%s" % loop_dev)
 
         loop_dev_obj = self.get_object(loop_dev_obj_path)
-        time.sleep(0.5)
 
         # should use the right backing file
         raw = self.get_property(loop_dev_obj, '.Loop', 'BackingFile')
-        # transcription from array of Bytes to string plus removal of trailing \0
-        backing_file = self.ay_to_str(raw)
-        self.assertEqual(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME), backing_file)
+        # transcription to array of Bytes to string plus adding the trailing \0
+        backing_file = self.str_to_ay(os.path.join(os.getcwd(), self.LOOP_DEVICE_FILENAME))
+        raw.assertEqual(backing_file)
 
         # should use the whole file except for the first 4096 bytes (offset)
         size = self.get_property(loop_dev_obj, ".Block", "Size")
-        self.assertEqual(size, 10 * 1024**2)
+        size.assertEqual(10 * 1024**2)
 
         # should be writable
         ro = self.get_property(loop_dev_obj, ".Block", "ReadOnly")
-        self.assertFalse(ro)
+        ro.assertFalse()
 
         # partitions shouldn't be scanned
         self.assertFalse(os.path.exists("/dev/%sp1" % loop_dev))


### PR DESCRIPTION
It sometimes take few seconds to update content of properties
on dbus after some change. Instead of putting 'random' sleeps
in our tests, 'get_property' now returns an object and running
'assertEqual' on it will check value of the property multiple
times before raising an AssertionError.