### PR TITLE
Deal with the spawn race condition

### DIFF
--- a/doc/udisks2-sections.txt.in.in
+++ b/doc/udisks2-sections.txt.in.in
@@ -173,6 +173,7 @@ udisks_base_job_get_type
 UDisksSpawnedJob
 udisks_spawned_job_new
 udisks_spawned_job_get_command_line
+udisks_spawned_job_start
 <SUBSECTION Standard>
 UDISKS_TYPE_SPAWNED_JOB
 UDISKS_SPAWNED_JOB

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -8,6 +8,11 @@ import storagedtestcase
 class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     '''This is a basic LVM test suite'''
 
+    @classmethod
+    def setUpClass(cls):
+        storagedtestcase.StoragedTestCase.setUpClass()
+        cls.ensure_modules_loaded()
+
     def _create_vg(self, vgname, devices):
         self.udev_settle()  # Since the devices might not be ready yet
         manager = self.get_object('/Manager')

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -72,6 +72,7 @@ test_spawned_job_successful (void)
   UDisksSpawnedJob *job;
 
   job = udisks_spawned_job_new ("/bin/true", NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_success), NULL);
   g_object_unref (job);
 }
@@ -84,6 +85,7 @@ test_spawned_job_failure (void)
   UDisksSpawnedJob *job;
 
   job = udisks_spawned_job_new ("/bin/false", NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Command-line `/bin/false' exited with non-zero exit status 1: ");
   g_object_unref (job);
@@ -97,6 +99,7 @@ test_spawned_job_missing_program (void)
   UDisksSpawnedJob *job;
 
   job = udisks_spawned_job_new ("/path/to/unknown/file", NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure), NULL);
   /* different GLib versions have different quoting style, be liberal */
   g_assert (strstr (last_failure_message, "Error spawning command-line"));
@@ -117,6 +120,7 @@ test_spawned_job_cancelled_at_start (void)
   cancellable = g_cancellable_new ();
   g_cancellable_cancel (cancellable);
   job = udisks_spawned_job_new ("/bin/true", NULL, getuid (), geteuid (), NULL, cancellable);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Operation was cancelled (g-io-error-quark, 19)");
   g_object_unref (job);
@@ -142,6 +146,7 @@ test_spawned_job_cancelled_midway (void)
 
   cancellable = g_cancellable_new ();
   job = udisks_spawned_job_new ("/bin/sleep 0.5", NULL, getuid (), geteuid (), NULL, cancellable);
+  udisks_spawned_job_start (job);
   g_timeout_add (10, on_timeout, cancellable); /* 10 msec */
   g_main_loop_run (loop);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
@@ -174,6 +179,7 @@ test_spawned_job_override_signal_handler (void)
   gboolean handler_ran;
 
   job = udisks_spawned_job_new ("/path/to/unknown/file", NULL, getuid (), geteuid (), NULL, NULL /* GCancellable */);
+  udisks_spawned_job_start (job);
   handler_ran = FALSE;
   g_signal_connect (job, "spawned-job-completed", G_CALLBACK (on_spawned_job_completed), &handler_ran);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure), NULL);
@@ -194,6 +200,7 @@ test_spawned_job_premature_termination (void)
   UDisksSpawnedJob *job;
 
   job = udisks_spawned_job_new ("/bin/sleep 1000", NULL, getuid (), geteuid (), NULL, NULL /* GCancellable */);
+  udisks_spawned_job_start (job);
   g_object_unref (job);
 }
 
@@ -225,6 +232,7 @@ test_spawned_job_read_stdout (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 0");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (read_stdout_on_spawned_job_completed), NULL);
   g_object_unref (job);
   g_free (s);
@@ -258,6 +266,7 @@ test_spawned_job_read_stderr (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 1");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (read_stderr_on_spawned_job_completed), NULL);
   g_object_unref (job);
   g_free (s);
@@ -289,6 +298,7 @@ test_spawned_job_exit_status (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 2");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (exit_status_on_spawned_job_completed),
                              GINT_TO_POINTER (1));
   g_object_unref (job);
@@ -296,6 +306,7 @@ test_spawned_job_exit_status (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 3");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (exit_status_on_spawned_job_completed),
                              GINT_TO_POINTER (2));
   g_object_unref (job);
@@ -312,6 +323,7 @@ test_spawned_job_abnormal_termination (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 4");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Command-line `./udisks-test-helper 4' was signaled with signal SIGSEGV (11): "
                              "OK, deliberately causing a segfault\n");
@@ -320,6 +332,7 @@ test_spawned_job_abnormal_termination (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 5");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Command-line `./udisks-test-helper 5' was signaled with signal SIGABRT (6): "
                              "OK, deliberately abort()'ing\n");
@@ -361,6 +374,7 @@ test_spawned_job_binary_output (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 6");
   job = udisks_spawned_job_new (s, NULL, getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (binary_output_on_spawned_job_completed), NULL);
   g_object_unref (job);
   g_free (s);
@@ -392,6 +406,7 @@ test_spawned_job_input_string (void)
 
   s = g_strdup_printf (UDISKS_TEST_DIR "/udisks-test-helper 7");
   job = udisks_spawned_job_new (s, "foobar", getuid (), geteuid (), NULL, NULL);
+  udisks_spawned_job_start (job);
   _g_assert_signal_received (job, "spawned-job-completed", G_CALLBACK (input_string_on_spawned_job_completed), NULL);
   g_object_unref (job);
   g_free (s);

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -642,8 +642,7 @@ udisks_daemon_launch_simple_job (UDisksDaemon    *daemon,
   if (object != NULL)
     udisks_base_job_add_object (UDISKS_BASE_JOB (job), object);
 
-  /* TODO: protect job_id by a mutex */
-  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", job_id++);
+  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", g_atomic_int_add (&job_id, 1));
   job_object = udisks_object_skeleton_new (job_object_path);
   udisks_object_skeleton_set_job (job_object, UDISKS_JOB (job));
   g_free (job_object_path);
@@ -715,8 +714,7 @@ udisks_daemon_launch_threaded_job  (UDisksDaemon          *daemon,
   if (object != NULL)
     udisks_base_job_add_object (UDISKS_BASE_JOB (job), object);
 
-  /* TODO: protect job_id by a mutex */
-  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", job_id++);
+  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", g_atomic_int_add (&job_id, 1));
   job_object = udisks_object_skeleton_new (job_object_path);
   udisks_object_skeleton_set_job (job_object, UDISKS_JOB (job));
   g_free (job_object_path);
@@ -793,8 +791,7 @@ udisks_daemon_launch_spawned_job (UDisksDaemon    *daemon,
   if (object != NULL)
     udisks_base_job_add_object (UDISKS_BASE_JOB (job), object);
 
-  /* TODO: protect job_id by a mutex */
-  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", job_id++);
+  job_object_path = g_strdup_printf ("/org/freedesktop/UDisks2/jobs/%u", g_atomic_int_add (&job_id, 1));
   job_object = udisks_object_skeleton_new (job_object_path);
   udisks_object_skeleton_set_job (job_object, UDISKS_JOB (job));
   g_free (job_object_path);

--- a/src/udisksdaemon.c
+++ b/src/udisksdaemon.c
@@ -920,6 +920,7 @@ udisks_daemon_launch_spawned_job_sync (UDisksDaemon    *daemon,
                           G_CALLBACK (spawned_job_sync_on_completed),
                           &data);
 
+  udisks_spawned_job_start (UDISKS_SPAWNED_JOB (job));
   g_main_loop_run (data.loop);
 
   if (out_status != NULL)

--- a/src/udiskslinuxfilesystem.c
+++ b/src/udiskslinuxfilesystem.c
@@ -1809,27 +1809,6 @@ handle_unmount (UDisksFilesystem      *filesystem,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-static void
-on_set_label_job_completed (UDisksJob   *job,
-                            gboolean     success,
-                            const gchar *message,
-                            gpointer     user_data)
-{
-  GDBusMethodInvocation *invocation = G_DBUS_METHOD_INVOCATION (user_data);
-  UDisksFilesystem *filesystem;
-
-  filesystem = UDISKS_FILESYSTEM (g_dbus_method_invocation_get_user_data (invocation));
-
-  if (success)
-    udisks_filesystem_complete_set_label (filesystem, invocation);
-  else
-    g_dbus_method_invocation_return_error (invocation,
-                                           UDISKS_ERROR,
-                                           UDISKS_ERROR_FAILED,
-                                           "Error setting label: %s",
-                                           message);
-}
-
 /* runs in thread dedicated to handling method call */
 static gboolean
 handle_set_label (UDisksFilesystem      *filesystem,
@@ -1843,13 +1822,15 @@ handle_set_label (UDisksFilesystem      *filesystem,
   const gchar *probed_fs_usage;
   const gchar *probed_fs_type;
   const FSInfo *fs_info;
-  UDisksBaseJob *job;
   const gchar *action_id;
   const gchar *message;
   gchar *real_label = NULL;
   uid_t caller_uid;
   gid_t caller_gid;
   gchar *command;
+  gint status = 0;
+  gchar *out_message = NULL;
+  gboolean success = FALSE;
   gchar *tmp;
   GError *error;
 
@@ -1995,24 +1976,32 @@ handle_set_label (UDisksFilesystem      *filesystem,
       g_free (tmp);
     }
 
-  job = udisks_daemon_launch_spawned_job (daemon,
-                                          object,
-                                          "filesystem-modify", caller_uid,
-                                          NULL, /* cancellable */
-                                          0,    /* uid_t run_as_uid */
-                                          0,    /* uid_t run_as_euid */
-                                          NULL, /* input_string */
-                                          "%s", command);
-  g_signal_connect (job,
-                    "completed",
-                    G_CALLBACK (on_set_label_job_completed),
-                    invocation);
+  success = udisks_daemon_launch_spawned_job_sync (daemon,
+                                                   object,
+                                                   "filesystem-modify", caller_uid,
+                                                   NULL, /* cancellable */
+                                                   0,    /* uid_t run_as_uid */
+                                                   0,    /* uid_t run_as_euid */
+                                                   &status,
+                                                   &out_message,
+                                                   NULL, /* input_string */
+                                                   "%s", command);
+
+  if (success)
+    udisks_filesystem_complete_set_label (filesystem, invocation);
+  else
+    g_dbus_method_invocation_return_error (invocation,
+                                           UDISKS_ERROR,
+                                           UDISKS_ERROR_FAILED,
+                                           "Error setting label: %s",
+                                           out_message);
 
  out:
   /* for some FSes we need to copy and modify label; free our copy */
   g_free (real_label);
   g_free (command);
   g_clear_object (&object);
+  g_free (out_message);
   return TRUE; /* returning TRUE means that we handled the method invocation */
 }
 

--- a/src/udisksspawnedjob.h
+++ b/src/udisksspawnedjob.h
@@ -37,6 +37,7 @@ UDisksSpawnedJob  *udisks_spawned_job_new              (const gchar  *command_li
                                                         UDisksDaemon *daemon,
                                                         GCancellable *cancellable);
 const gchar       *udisks_spawned_job_get_command_line (UDisksSpawnedJob *job);
+void udisks_spawned_job_start (UDisksSpawnedJob *job);
 
 G_END_DECLS
 


### PR DESCRIPTION
The goal of this PR is to eliminate the issues caused by the [race condition when spawning processes](https://github.com/storaged-project/storaged/issues/147) which is causing our tests to fail quite often and which can cause severe issues in production. There are two things that should happen here:

- [x] replace calls of ``launch_spawned_job()`` with ``launch_spawned_job_sync()`` where possible
- [x] fix the race condition in ``launch_spawned_job()``

``launch_spawned_job_sync()`` doesn't suffer from the race condition because it runs it's own main loop (in which signals are handled) after it connects the ``::completed`` signal. However, we can use it in all places where we spawn processes right now because none of the places has much to do after the processed is spawned (just some cleanup which can wait for the process to finish).

On the other hand, we still want to eliminate the race condition for future optimizations or development requiring ``launch_spawned_job()``.