### PR TITLE
Get rid of the compiler warnings

### DIFF
--- a/modules/bcache/udiskslinuxmanagerbcache.c
+++ b/modules/bcache/udiskslinuxmanagerbcache.c
@@ -217,7 +217,8 @@ handle_bcache_create (UDisksManagerBcache    *object,
                                      N_("Authentication is required to create bcache device."),
                                      invocation);
 
-  if (! bd_kbd_bcache_create (backing_dev, cache_dev, NULL, &bcache, &error))
+  /* XXX: the type casting below looks like a bug in libblockdev */
+  if (! bd_kbd_bcache_create (backing_dev, cache_dev, NULL, (const gchar **) &bcache, &error))
     {
       g_dbus_method_invocation_take_error (invocation, error);
       goto out;

--- a/modules/bcache/udiskslinuxmanagerbcache.c
+++ b/modules/bcache/udiskslinuxmanagerbcache.c
@@ -224,10 +224,7 @@ handle_bcache_create (UDisksManagerBcache    *object,
       goto out;
     }
 
-  if (! bcache)
-    bcache = g_strdup("Failed to get bcache device name");
-
-    udisks_manager_bcache_complete_bcache_create (object, invocation, bcache);
+  udisks_manager_bcache_complete_bcache_create (object, invocation, bcache);
 out:
   g_free (backing_dev);
   g_free (cache_dev);


### PR DESCRIPTION
These are the last two compiler warnings we are getting, let's get rid of them. Ideally we should compile stuff with ``-Werror``, but there are some issues with this option in combination with ``-O0`` (added by ``--enable-debug`` option).  However, this is a step forward in that direction.

This fixes https://github.com/storaged-project/storaged/issues/118