### PR TITLE
udev: Ignore ram block devices

### DIFF
--- a/data/80-udisks2.rules
+++ b/data/80-udisks2.rules
@@ -153,3 +153,6 @@ ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0", ENV{ID_PART_ENTR
 
 # Zram devices setup
 KERNEL=="zram[0-9]", ENV{SYSTEMD_WANTS}="zram-setup@zram%n.service", TAG+="systemd"
+
+# Explicitly ignore ram block devices, they don't work with udev
+KERNEL=="ram*", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
They are not whitelisted by the rest of the rules, and it looks like
they don't get synthesized "change" events in any case.
