### PR TITLE
Fix PolicyKit action ids for bcache, btrfs and zram modules

### DIFF
--- a/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
+++ b/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
@@ -9,7 +9,7 @@
   <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
-  <action id="org.freedesktop.UDisks2.bcache.manage-bcache">
+  <action id="org.freedesktop.udisks2.bcache.manage-bcache">
     <_description>Manage Bcache</_description>
     <_message>Authentication is required to manage Bcache</_message>
     <defaults>

--- a/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
+++ b/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
@@ -12,7 +12,7 @@
   <!-- ###################################################################### -->
   <!-- Manage BTRFS -->
 
-  <action id="org.freedesktop.UDisks2.btrfs.manage-btrfs">
+  <action id="org.freedesktop.udisks2.btrfs.manage-btrfs">
     <_description>Manage BTRFS</_description>
     <_message>Authentication is required to manage BTRFS</_message>
     <defaults>

--- a/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
+++ b/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
@@ -3,13 +3,13 @@
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
- 
+
 <policyconfig>
   <vendor>The Storaged Project</vendor>
   <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
-  <action id="org.freedesktop.UDisks2.zram.manage-zram">
+  <action id="org.freedesktop.udisks2.zram.manage-zram">
     <_description>Manage zRAM</_description>
     <_message>Authentication is required to manage zRAM</_message>
     <defaults>
@@ -20,4 +20,3 @@
   </action>
 
 </policyconfig>
-


### PR DESCRIPTION
Action ids are case sensitive and we expect them to be lowercase.