### PR TITLE
Fix docs for the new LsmLocal interface

### DIFF
--- a/modules/lsm/data/org.freedesktop.UDisks2.lsm.xml
+++ b/modules/lsm/data/org.freedesktop.UDisks2.lsm.xml
@@ -121,6 +121,7 @@
   -->
   <interface name="org.freedesktop.UDisks2.Manager.LSM">
   </interface>
+
   <!--
     org.freedesktop.UDisks2.Drive.LsmLocal:
     @short_description: Interface exported on disk drive objects for managing
@@ -135,8 +136,7 @@
     <!--
         TurnIdentLEDOn:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
 
         Turn on the identification LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -150,8 +150,7 @@
     <!--
         TurnIdentLEDOff:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
 
         Turn off the identification LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -165,8 +164,7 @@
     <!--
         TurnFaultLEDOn:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
 
         Turn on the fault LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -180,8 +178,7 @@
     <!--
         TurnFaultLEDOff:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
 
         Turn off the fault LED of disk.
         This method only works on SCSI enclosure disks yet.


### PR DESCRIPTION
Paragraphs in the documentation are preserved and converted into
<para>...</para> in the resulting generated docbook file. Thus if a newline
separates tag from its attributes, the result is an invalid XML file containing
things like this:

<link<para>....

Let's just don't be superstrict about number of characters on a line a get rid
of the extra newlines that cause these issues.