### PR TITLE
LSM module: Fix document compile failure.

### DIFF
--- a/modules/lsm/data/org.freedesktop.UDisks2.lsm.xml
+++ b/modules/lsm/data/org.freedesktop.UDisks2.lsm.xml
@@ -135,8 +135,8 @@
     <!--
         TurnIdentLEDOn:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for
+                  <link linkend="udisks-std-options">standard options</link>).
 
         Turn on the identification LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -150,8 +150,8 @@
     <!--
         TurnIdentLEDOff:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for
+                  <link linkend="udisks-std-options">standard options</link>).
 
         Turn off the identification LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -165,8 +165,8 @@
     <!--
         TurnFaultLEDOn:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for
+                  <link linkend="udisks-std-options">standard options</link>).
 
         Turn on the fault LED of disk.
         This method only works on SCSI enclosure disks yet.
@@ -180,8 +180,8 @@
     <!--
         TurnFaultLEDOff:
         @since: 2.6.3
-        @options: Options (currently unused except for <link
-                  linkend="udisks-std-options">standard options</link>).
+        @options: Options (currently unused except for
+                  <link linkend="udisks-std-options">standard options</link>).
 
         Turn off the fault LED of disk.
         This method only works on SCSI enclosure disks yet.


### PR DESCRIPTION
Error:

    ../../modules/lsm/doc_generated-org.freedesktop.UDisks2.Drive.LsmLocal.xml:34:
    parser error : Opening and ending tag mismatch: para line 34 and link
    <para>                  linkend="udisks-std-options">standard
    options</link>).

Root cause:

    `<link>` and `</link>` should be in the same line in xml document comment.

Signed-off-by: Gris Ge <fge@redhat.com>