### PR TITLE
LSM packaging fixes

### DIFF
--- a/modules/lsm/data/Makefile.am
+++ b/modules/lsm/data/Makefile.am
@@ -13,4 +13,8 @@ modulesconf_DATA = udisks2_lsm.conf
 EXTRA_DIST = \
 	org.freedesktop.UDisks2.lsm.xml \
 	udisks2_lsm.conf \
+	$(polkit_in_files) \
 	$(NULL)
+
+clean-local:
+	rm -f *~ $(polkit_DATA)

--- a/packaging/storaged.spec.in
+++ b/packaging/storaged.spec.in
@@ -311,6 +311,7 @@ systemctl try-restart udisks2
 %dir %{_sysconfdir}/udisks2/modules.conf.d
 %{_libdir}/udisks2/modules/libudisks2_lsm.so
 %{_mandir}/man5/udisks2_lsm.conf.*
+%{_datadir}/polkit-1/actions/org.freedesktop.UDisks2.lsm.policy
 %attr(0600,root,root) %{_sysconfdir}/udisks2/modules.conf.d/udisks2_lsm.conf
 
 %files -n %{name}-zram


### PR DESCRIPTION
Two fixes related the recent LSM changes -- new policy file needs to be included in the source archive and added to the `%files` section of the `storaged-lsm` package in the spec file.