### PR TITLE
Build with libblockdev's bcache functionality enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -455,7 +455,7 @@ if test "x$enable_bcache" = "xyes" \
     CFLAGS=$SAVE_CFLAGS
     LDFLAGS=$SAVE_LDFLAGS
 
-    BCACHE_CFLAGS=""
+    BCACHE_CFLAGS="-DWITH_BD_BCACHE"
     BCACHE_LIBS="-lbd_kbd"
 
     if test "x$have_bcache" = "xno"; then


### PR DESCRIPTION
Bcache functionality in the libblockdev-kbd plugin is now optional. If we were
using pkg-config, we would get proper cflags, but since we are using
libblockdev's plugins as standalone libraries, we need to do this on our
own. This makes sure the WITH_BD_BCACHE macro is defined which enables the
bcache functionality when building things with the libblockdev-kbd plugin.