### PR TITLE
Do not stop the MD array before deletion in DBus tests

### DIFF
--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -218,11 +218,6 @@ class RAID0TestCase(RAIDLevel):
         name = 'storaged_test_delete'
         array = self._array_create(name)
 
-        # stop the array
-        array.Stop(self.no_options, dbus_interface=self.iface_prefix + '.MDRaid')
-        ret, _out = self.run_command('mdadm /dev/md/%s' % name)
-        self.assertEqual(ret, 1)
-
         # delete
         array.Delete(self.no_options, dbus_interface=self.iface_prefix + '.MDRaid')
         self.udev_settle()


### PR DESCRIPTION
The Delete() method takes care of stopping the array (if needed)
and stopping it explicitly before just creates a race condition
due to uevents handling.