### PR TITLE
Trigger update on the mdraid object after bitmap location change

### DIFF
--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -310,7 +310,6 @@ class RAID1TestCase(RAIDLevel):
         _ret, out = self.run_command('lsblk -no FSTYPE %s' % new_path)
         self.assertEqual(out, '')
 
-    @unittest.skip("Magically failing test")
     def test_bitmap_location(self):
         array_name = 'storaged_test_bitmap'
         array = self._array_create(array_name)

--- a/src/udiskslinuxmdraid.c
+++ b/src/udiskslinuxmdraid.c
@@ -1480,6 +1480,7 @@ handle_set_bitmap_location (UDisksMDRaid           *_mdraid,
     }
 
   udisks_mdraid_complete_add_device (_mdraid, invocation);
+  udisks_linux_mdraid_update (mdraid, object);
 
  out:
   g_free (error_message);


### PR DESCRIPTION
Changing bitmap location to 'none' doesn't trigger the change
uevent so we need to run the update function manually.