### PR TITLE
LSM: Add policy file to POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -15,6 +15,7 @@ modules/lvm2/data/org.freedesktop.UDisks2.lvm2.policy.in
 modules/lvm2/udiskslinuxlogicalvolume.c
 modules/lvm2/udiskslinuxmanagerlvm2.c
 modules/lvm2/udiskslinuxvolumegroup.c
+modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in
 modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
 modules/zram/udiskslinuxmanagerzram.c
 modules/zram/udiskslinuxblockzram.c


### PR DESCRIPTION
Fixes "make check" error:

    The following files contain translations and are currently not in use. Please
    consider adding these to the POTFILES.in file, located in the po/ directory.

    modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in

Note that the .c files in lsm/ don't have any translations, so they don't need to be added.