### PR TITLE
Rename storaged back to udisks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ gtk-doc.make
 intltool-*
 libtool
 m4/
-packaging/storaged.spec
+packaging/udisks2.spec
 po/POTFILES
 po/Makefile.in.in
 src/*-marshal.*

--- a/HACKING
+++ b/HACKING
@@ -18,7 +18,7 @@ SOURCE CONTROL
 
 Anonymous checkouts:
 
-  $ git clone git@github.com:storaged-project/storaged.git
+  $ git clone git@github.com:storaged-project/udisks.git
 
 MAKING RELEASES
 ===============
@@ -41,7 +41,7 @@ Checklist for making a release:
    - Ensure newly added API is marked properly with "Since: X.Y"
    - Ensure that deprecated API is marked as such
 
- - Tag the release: git tag storaged-X.Y.Z
+ - Tag the release: git tag udisks-X.Y.Z
 
  - Post-release actions:
    - Bump the version in configure.in
@@ -54,7 +54,7 @@ starting the 2.0.0, 2.1.0, 2.2.0 etc. series), do the following
 
  - Update the date in man pages to "$MONTH $YEAR" e.g. "October 2012"
 
- - At some point after the release, create the storaged-X-Y branch
+ - At some point after the release, create the udisks-X-Y branch
    - Perform the post-release actions above on the created branch
    - This is for maintenance releases
    - Do this when focus is on new feature development
@@ -63,7 +63,7 @@ starting the 2.0.0, 2.1.0, 2.2.0 etc. series), do the following
 
 For maintenance releases, the rules are simple
 
- - Work on the storaged-X-Y branch
+ - Work on the udisks-X-Y branch
  - If possible, cherry-pick fixes from master ('git cherry-pick')
  - Do not add (or backport) any new API or features
  - Do not add, remove or change any translatable strings

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ DISTCHECK_CONFIGURE_FLAGS =                                                    \
 	$(NULL)
 
 sign: dist
-	gpg --armor --detach-sign --output storaged-$(VERSION).tar.bz2.sign storaged-$(VERSION).tar.bz2
+	gpg --armor --detach-sign --output udisks-$(VERSION).tar.bz2.sign udisks-$(VERSION).tar.bz2
 
 shortlog:
 	git shortlog -r $$(git tag -l | tail -n 1)..HEAD
@@ -70,7 +70,7 @@ rpm: dist-bzip2
 		--define "_builddir $(RPMDIR)" \
 		--define "_srcrpmdir $(RPMDIR)" \
 		--define "_rpmdir $(RPMDIR)" \
-		-ba $(SRCDIR)/packaging/storaged.spec
+		-ba $(SRCDIR)/packaging/udisks2.spec
 srpm: dist-bzip2
 	rpmbuild \
 		--define "_sourcedir $(SRCDIR)" \
@@ -78,4 +78,4 @@ srpm: dist-bzip2
 		--define "_builddir $(RPMDIR)" \
 		--define "_srcrpmdir $(RPMDIR)" \
 		--define "_rpmdir $(RPMDIR)" \
-		-bs $(SRCDIR)/packaging/storaged.spec
+		-bs $(SRCDIR)/packaging/udisks2.spec

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
----------------------------
-storaged 2.6.4 (unreleased)
----------------------------
+-------------------------
+udisks 2.6.4 (unreleased)
+-------------------------
 
 The storaged project provides a daemon, tools and libraries to access
 and manipulate disks, storage devices and technologies.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@
 OVERVIEW
 ========
 
-The Storaged project provides a daemon, tools and libraries to access and
+The Udisks project provides a daemon, tools and libraries to access and
 manipulate disks, storage devices and technologies.
 
-*Storaged is a fork of UDisks2 and extends its DBus API; it is meant to be a
-drop-in replacement for the original project.*
-
-For API stability and intended audience of Storaged, see the API STABILITY and
+For API stability and intended audience of Udisks, see the API STABILITY and
 AUDIENCE section of the `udisks(8)` man page (`doc/man/udisks.xml` in the
 tarball and git repository).
 
@@ -26,24 +23,24 @@ later).
 INSTALLATION
 ============
 
-Storaged has several dependencies listed in `packaging/storaged.spec`.
+Udisks has several dependencies listed in `packaging/udisks2.spec`.
 
 If you run rpm based distro, install the dependencies by:
 
-    # dnf builddep -y packaging/storaged.spec
+    # dnf builddep -y packaging/udisks2.spec
 
 AUTOTOOLS
 ---------
 
-To configure and install the Storaged, perform following tasks:
+To configure and install the Udisks, perform following tasks:
 
     $ ./autogen.sh
 
-Additional functionality of Storaged for monitoring and management is split
+Additional functionality of Udisks for monitoring and management is split
 into several modules: *BCache, BTRFS, iSCSI, libStorageManagement, LVM2, LVM
 Cache and zRAM*. By default, no additional module will be built.
 
-To build Storaged with (a) chosen module(s), provide or leave these
+To build Udisks with (a) chosen module(s), provide or leave these
 configuration options for the `configure` script:
 
     $ ./configure --enable-bcache --enable-btrfs --enable-iscsi
@@ -62,9 +59,9 @@ The actual build and installation:
 RELEASES
 ========
 
-Releases of Storaged are available in compressed tarballs from
+Releases of Udisks are available in compressed tarballs from
 
- https://github.com/storaged-project/storaged/releases
+ https://github.com/storaged-project/udisks/releases
 
 
 BUGS and DEVELOPMENT
@@ -72,4 +69,4 @@ BUGS and DEVELOPMENT
 
 Please report bugs via the GitHub's issues tracker at
 
- https://github.com/storaged-project/storaged/issues
+ https://github.com/storaged-project/udisks/issues

--- a/configure.ac
+++ b/configure.ac
@@ -1,15 +1,15 @@
 
-m4_define([storaged_major_version], [2])
-m4_define([storaged_minor_version], [6])
-m4_define([storaged_micro_version], [4])
+m4_define([udisks_major_version], [2])
+m4_define([udisks_minor_version], [6])
+m4_define([udisks_micro_version], [4])
 
-m4_define([udisks_version], [storaged_major_version.storaged_minor_version.storaged_micro_version])
+m4_define([udisks_version], [udisks_major_version.udisks_minor_version.udisks_micro_version])
 
-AC_INIT([storaged],[udisks_version],[https://storaged-project.github.io],[storaged])
+AC_INIT([udisks],[udisks_version],[https://storaged-project.github.io],[udisks])
 
-UDISKS_MAJOR_VERSION=storaged_major_version
-UDISKS_MINOR_VERSION=storaged_minor_version
-UDISKS_MICRO_VERSION=storaged_micro_version
+UDISKS_MAJOR_VERSION=udisks_major_version
+UDISKS_MINOR_VERSION=udisks_minor_version
+UDISKS_MICRO_VERSION=udisks_micro_version
 UDISKS_VERSION=udisks_version
 AC_SUBST(UDISKS_MAJOR_VERSION)
 AC_SUBST(UDISKS_MINOR_VERSION)
@@ -523,7 +523,7 @@ src/Makefile
 src/tests/Makefile
 tools/Makefile
 packaging/Makefile
-packaging/storaged.spec
+packaging/udisks2.spec
 modules/Makefile
 modules/btrfs/Makefile
 modules/btrfs/data/Makefile

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,5 +1,5 @@
-org.storaged.*.conf
-org.storaged.*.service
-org.storaged.*.policy
+org.freedesktop.*.conf
+org.freedesktop.*.service
+org.freedesktop.*.policy
 *.pc
 

--- a/data/org.freedesktop.UDisks2.policy.in
+++ b/data/org.freedesktop.UDisks2.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <!-- ###################################################################### -->

--- a/data/org.freedesktop.UDisks2.xml
+++ b/data/org.freedesktop.UDisks2.xml
@@ -1281,7 +1281,7 @@
 
         If the option <parameter>dry-run-first</parameter> is set to
         %TRUE then a dry run of the formatting command is performed
-        first, if Storaged knows how to do that.  The idea is that
+        first, if Udisks knows how to do that.  The idea is that
         this allows a deeper check of the parameters even when
         <parameter>no-block</parameter> is %TRUE.
 
@@ -1437,7 +1437,7 @@
         @size: The desired size of the partition, in bytes.
         @type: The type of partition to create (cf. the #org.freedesktop.UDisks2.Partition:Type property) or blank to use the default for the partition table type and OS.
         @name: The name for the new partition or blank if the partition table do not support names.
-        @options: Options (currently unused except for <link linkend="storaged-std-options">standard options</link>).
+        @options: Options (currently unused except for <link linkend="udisks-std-options">standard options</link>).
         @created_partition: An object path to the created block device object implementing the #org.freedesktop.UDisks2.Partition interface.
         @format_type: The type to use for Format.
         @format_options: Options for Format.

--- a/doc/man/udisks-lvm.xml.in
+++ b/doc/man/udisks-lvm.xml.in
@@ -81,7 +81,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/udisks.xml.in
+++ b/doc/man/udisks.xml.in
@@ -389,7 +389,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/udisks2.conf.5.xml.in.in
+++ b/doc/man/udisks2.conf.5.xml.in.in
@@ -87,7 +87,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/udisks2_lsm.conf.5.xml.in.in
+++ b/doc/man/udisks2_lsm.conf.5.xml.in.in
@@ -172,7 +172,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/udisksctl.xml.in
+++ b/doc/man/udisksctl.xml.in
@@ -358,7 +358,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/udisksd.xml.in
+++ b/doc/man/udisksd.xml.in
@@ -113,7 +113,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/man/umount.udisks2.xml.in
+++ b/doc/man/umount.udisks2.xml.in
@@ -44,7 +44,7 @@
     <para>
       Please send bug reports to either the distribution bug tracker
       or the upstream bug tracker at
-      <ulink url="https://github.com/storaged-project/storaged/issues"/>.
+      <ulink url="https://github.com/storaged-project/udisks/issues"/>.
     </para>
   </refsect1>
 

--- a/doc/uml/classes.txt
+++ b/doc/uml/classes.txt
@@ -2,35 +2,35 @@
 
 skinparam defaultFontName Monospaced
 
-StoragedDaemon "1" *-- StoragedModuleManager
+UdisksDaemon "1" *-- UdisksModuleManager
 
-class StoragedDaemon {
+class UdisksDaemon {
     GDBusConnection          *get_connection()
-    GDBusObjectManagerServer *storaged_daemon_get_object_manager()
-    StoragedMountMonitor     *storaged_daemon_get_mount_monitor()
-    StoragedFstabMonitor     *storaged_daemon_get_fstab_monitor()
-    StoragedCrypttabMonitor  *storaged_daemon_get_crypttab_monitor()
-    StoragedLinuxProvider    *storaged_daemon_get_linux_provider()
-    PolkitAuthority          *storaged_daemon_get_authority()
-    StoragedState            *storaged_daemon_get_state()
-    StoragedModuleManager    *storaged_daemon_get_module_manager()
-    gboolean                  storaged_daemon_get_disable_modules()
-    gboolean                  storaged_daemon_get_force_load_modules()
-    gboolean                  storaged_daemon_get_uninstalled()
+    GDBusObjectManagerServer *udisks_daemon_get_object_manager()
+    UdisksMountMonitor     *udisks_daemon_get_mount_monitor()
+    UdisksFstabMonitor     *udisks_daemon_get_fstab_monitor()
+    UdisksCrypttabMonitor  *udisks_daemon_get_crypttab_monitor()
+    UdisksLinuxProvider    *udisks_daemon_get_linux_provider()
+    PolkitAuthority          *udisks_daemon_get_authority()
+    UdisksState            *udisks_daemon_get_state()
+    UdisksModuleManager    *udisks_daemon_get_module_manager()
+    gboolean                  udisks_daemon_get_disable_modules()
+    gboolean                  udisks_daemon_get_force_load_modules()
+    gboolean                  udisks_daemon_get_uninstalled()
 }
 
-class StoragedModuleManager {
-    gboolean storaged_module_manager_get_modules_available ()
-    gboolean storaged_module_manager_get_uninstalled()
-    void     storaged_module_manager_load_modules()
+class UdisksModuleManager {
+    gboolean udisks_module_manager_get_modules_available ()
+    gboolean udisks_module_manager_get_uninstalled()
+    void     udisks_module_manager_load_modules()
 
-    GList   *storaged_module_manager_get_block_object_iface_infos()
-    GList   *storaged_module_manager_get_drive_object_iface_infos()
-    GList   *storaged_module_manager_get_module_object_new_funcs()
-    GList   *storaged_module_manager_get_new_manager_iface_funcs()
+    GList   *udisks_module_manager_get_block_object_iface_infos()
+    GList   *udisks_module_manager_get_drive_object_iface_infos()
+    GList   *udisks_module_manager_get_module_object_new_funcs()
+    GList   *udisks_module_manager_get_new_manager_iface_funcs()
 
-    void     storaged_module_manager_set_module_state_pointer()
-    gpointer storaged_module_manager_get_module_state_pointer()
+    void     udisks_module_manager_set_module_state_pointer()
+    gpointer udisks_module_manager_get_module_state_pointer()
 }
 
 @enduml

--- a/modules/Makefile.uninstalled
+++ b/modules/Makefile.uninstalled
@@ -1,4 +1,4 @@
-# Due to --uninstalled option passed to storaged
+# Due to --uninstalled option passed to udisks
 module_link:
 	$(AM_V_at) if [ ! -L ../$(MODULE_SO) ]; then ln -r -s .libs/$(MODULE_SO) ..; fi
 

--- a/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
+++ b/modules/bcache/data/org.freedesktop.UDisks2.bcache.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <action id="org.freedesktop.udisks2.bcache.manage-bcache">

--- a/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
+++ b/modules/btrfs/data/org.freedesktop.UDisks2.btrfs.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <!-- ###################################################################### -->

--- a/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.policy.in
+++ b/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.policy.in
@@ -6,7 +6,7 @@
 
 <policyconfig>
   <vendor>The UDisks Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <!-- ###################################################################### -->

--- a/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.xml
+++ b/modules/iscsi/data/org.freedesktop.UDisks2.iscsi.xml
@@ -183,7 +183,7 @@
     </method>
 
     <!--
-        SessionsSupported: Whether or not this version of Storaged
+        SessionsSupported: Whether or not this version of Udisks
         supports ISCSI.Session objects.
     -->
     <property name="SessionsSupported" type="b" access="read"/>
@@ -195,7 +195,7 @@
       @short_description: iSCSI session.
 
       This interface should appear on a separate object exported on the master
-      Storaged root.
+      Udisks root.
   -->
   <interface name="org.freedesktop.UDisks2.ISCSI.Session">
     <annotation name="org.gtk.GDBus.C.Name" value="ISCSI_Session"/>

--- a/modules/lsm/README_DEV_lsm.txt
+++ b/modules/lsm/README_DEV_lsm.txt
@@ -29,7 +29,7 @@
     systemctl start libstoragemgmt
     lsmcli ls -l -u ontap://root@na-sim -P      # Input ONTAP password.
  * It should print some information about this ONTAP array.
- * Compile and install Storaged project with lsm module:
+ * Compile and install Udisks project with lsm module:
     ./autogen.sh  --libdir=/usr/lib64 --prefix=/usr  --sysconfdir /etc \
         --enable-lsm
     make -j5

--- a/modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in
+++ b/modules/lsm/data/org.freedesktop.UDisks2.lsm.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <!-- ###################################################################### -->

--- a/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.policy.in
+++ b/modules/lvm2/data/org.freedesktop.UDisks2.lvm2.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <!-- ###################################################################### -->

--- a/modules/lvm2/udiskslvmhelper.c
+++ b/modules/lvm2/udiskslvmhelper.c
@@ -18,13 +18,13 @@
  *
  */
 
-/* This is a helper program used by Storaged to query the state of
+/* This is a helper program used by Udisks to query the state of
    LVM2 via the lvm2app library.
 
    The reasoning for doing this in a separate process goes like this:
    Calling lvm_vg_open might block for a long time when the volume
    group is locked by someone else.  When this happens, only that one
-   volume group should be affected.  No other part of Storaged and no
+   volume group should be affected.  No other part of Udisks and no
    other volume group updates should wait for it.  It doesn't seem to
    be possible to set "wait_for_locks" temporarily when using lvm2app,
    and we actually do want to wait the short amounts of time that a

--- a/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
+++ b/modules/zram/data/org.freedesktop.UDisks2.zram.policy.in
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 
 <policyconfig>
-  <vendor>The Storaged Project</vendor>
-  <vendor_url>https://github.com/storaged-project/storaged</vendor_url>
+  <vendor>The Udisks Project</vendor>
+  <vendor_url>https://github.com/storaged-project/udisks</vendor_url>
   <icon_name>drive-removable-media</icon_name>
 
   <action id="org.freedesktop.udisks2.zram.manage-zram">

--- a/packaging/Makefile.am
+++ b/packaging/Makefile.am
@@ -1,1 +1,1 @@
-EXTRA_DIST = storaged.spec.in generate
+EXTRA_DIST = udisks2.spec.in generate

--- a/packaging/generate
+++ b/packaging/generate
@@ -17,10 +17,10 @@ case "$1" in
         ;;
 
     -l|--with-libblockdev-part)
-        sed "s/@have_libblockdev_part_spec@/1/" storaged.spec.in > storaged.spec
+        sed "s/@have_libblockdev_part_spec@/1/" udisks2.spec.in > udisks2.spec
         ;;
 
     -p|--with-parted|*)
-        sed "s/@have_libblockdev_part_spec@/0/" storaged.spec.in > storaged.spec
+        sed "s/@have_libblockdev_part_spec@/0/" udisks2.spec.in > udisks2.spec
         ;;
 esac

--- a/packaging/udisks2.spec.in
+++ b/packaging/udisks2.spec.in
@@ -13,7 +13,7 @@
 %define git_hash                        %(git log -1 --pretty=format:"%h" || true)
 %define build_date                      %(date '+%Y%m%d')
 
-Name:    udisks
+Name:    udisks2
 Summary: Disk Manager
 Version: 2.6.4
 %if %{is_git} == 0
@@ -77,22 +77,19 @@ Requires: ntfsprogs
 # For /proc/self/mountinfo, only available in 2.6.26 or higher
 Conflicts: kernel < 2.6.26
 
-Provides:  udisks2 = %{version}-%{release}
-Obsoletes: udisks2
+Provides:  storaged = %{version}-%{release}
+Obsoletes: storaged
 
 %description
 The Udisks project provides a daemon, tools and libraries to access and
 manipulate disks, storage devices and technologies.
 
-Udisks is a fork of UDisks2 and extends its DBus API; it is meant to be a
-drop-in replacement for the original project.
-
 %package -n lib%{name}
 Summary: Dynamic library to access the udisksd daemon
 Group: System Environment/Libraries
 License: LGPLv2+
-Provides:  libudisks2 = %{version}-%{release}
-Obsoletes: libudisks2
+Provides:  libstoraged = %{version}-%{release}
+Obsoletes: libstoraged
 
 %description -n lib%{name}
 This package contains the dynamic library, which provides
@@ -105,6 +102,8 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
 Requires: iscsi-initiator-utils
 BuildRequires: iscsi-initiator-utils-devel
+Provides:  storaged-iscsi = %{version}-%{release}
+Obsoletes: storaged-iscsi
 
 %description -n %{name}-iscsi
 This package contains module for iSCSI configuration.
@@ -116,6 +115,8 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
 Requires: lvm2
 BuildRequires: lvm2-devel
+Provides:  storaged-lvm2 = %{version}-%{release}
+Obsoletes: storaged-lvm2
 
 %description -n %{name}-lvm2
 This package contains module for LVM2 configuration.
@@ -125,8 +126,8 @@ Summary: Development files for lib%{name}
 Group: Development/Libraries
 Requires: lib%{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
-Provides:  libudisks2-devel = %{version}-%{release}
-Obsoletes: libudisks2-devel
+Provides:  libstoraged-devel = %{version}-%{release}
+Obsoletes: libstoraged-devel
 
 %description -n lib%{name}-devel
 This package contains the development files for the library lib%{name}, a
@@ -140,6 +141,8 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
 Requires: libblockdev-kbd
 BuildRequires: libblockdev-kbd-devel
+Provides:  storaged-bcache = %{version}-%{release}
+Obsoletes: storaged-bcache
 
 %description -n %{name}-bcache
 This package contains module for Bcache configuration.
@@ -151,6 +154,8 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 License: LGPLv2+
 Requires: libblockdev-btrfs
 BuildRequires: libblockdev-btrfs-devel
+Provides:  storaged-btrfs = %{version}-%{release}
+Obsoletes: storaged-btrfs
 
 %description -n %{name}-btrfs
 This package contains module for BTRFS configuration.
@@ -163,6 +168,8 @@ License: LGPLv2+
 Requires: libstoragemgmt
 BuildRequires: libstoragemgmt-devel
 BuildRequires: libconfig-devel
+Provides:  storaged-lsm = %{version}-%{release}
+Obsoletes: storaged-lsm
 
 %description -n %{name}-lsm
 This package contains module for LSM configuration.
@@ -176,6 +183,8 @@ Requires: libblockdev-kbd
 Requires: libblockdev-swap
 BuildRequires: libblockdev-kbd-devel
 BuildRequires: libblockdev-swap-devel
+Provides:  storaged-zram = %{version}-%{release}
+Obsoletes: storaged-zram
 
 %description -n %{name}-zram
 This package contains module for ZRAM configuration.

--- a/packaging/udisks2.spec.in
+++ b/packaging/udisks2.spec.in
@@ -13,7 +13,7 @@
 %define git_hash                        %(git log -1 --pretty=format:"%h" || true)
 %define build_date                      %(date '+%Y%m%d')
 
-Name:    storaged
+Name:    udisks
 Summary: Disk Manager
 Version: 2.6.4
 %if %{is_git} == 0
@@ -23,8 +23,8 @@ Release: 0.%{build_date}git%{git_hash}%{?dist}
 %endif
 License: GPLv2+
 Group:   System Environment/Libraries
-URL:     https://github.com/storaged-project/storaged
-Source0: https://github.com/storaged-project/storaged/releases/download/storaged-%{version}/storaged-%{version}.tar.bz2
+URL:     https://github.com/storaged-project/udisks
+Source0: https://github.com/storaged-project/udisks/releases/download/udisks-%{version}/udisks-%{version}.tar.bz2
 
 BuildRequires: glib2-devel >= %{glib2_version}
 BuildRequires: gobject-introspection-devel >= %{gobject_introspection_version}
@@ -81,10 +81,10 @@ Provides:  udisks2 = %{version}-%{release}
 Obsoletes: udisks2
 
 %description
-The Storaged project provides a daemon, tools and libraries to access and
+The Udisks project provides a daemon, tools and libraries to access and
 manipulate disks, storage devices and technologies.
 
-Storaged is a fork of UDisks2 and extends its DBus API; it is meant to be a
+Udisks is a fork of UDisks2 and extends its DBus API; it is meant to be a
 drop-in replacement for the original project.
 
 %package -n lib%{name}
@@ -182,7 +182,7 @@ This package contains module for ZRAM configuration.
 %endif
 
 %prep
-%setup -q -n storaged-%{version}
+%setup -q -n udisks-%{version}
 
 %build
 autoreconf -ivf

--- a/po/de.po
+++ b/po/de.po
@@ -1566,7 +1566,7 @@ msgstr "Intel RSTe RAID-Bestandteil (%s)"
 #: ../udisks/udisksclient.c:1952
 msgctxt "fs-type"
 msgid "Intel Rapid Storage Technology enterprise RAID Member"
-msgstr "Intel Rapid Storaged Technology enterprise RAID-Bestandteil"
+msgstr "Intel Rapid Storage Technology enterprise RAID-Bestandteil"
 
 #: ../udisks/udisksclient.c:1952
 msgctxt "fs-type"

--- a/src/tests/dbus-tests/run_tests.py
+++ b/src/tests/dbus-tests/run_tests.py
@@ -6,7 +6,7 @@ import time
 import subprocess
 import argparse
 import unittest
-import storagedtestcase
+import udiskstestcase
 import glob
 import shutil
 import tempfile
@@ -15,17 +15,13 @@ import re
 
 def find_daemon(projdir, system):
     if not system:
-        if os.path.exists(os.path.join(projdir, 'src', 'storaged')):
-            daemon_bin = 'storaged'
-        elif os.path.exists(os.path.join(projdir, 'src', 'udisksd')):
+        if os.path.exists(os.path.join(projdir, 'src', 'udisksd')):
             daemon_bin = 'udisksd'
         else:
             print("Cannot find the daemon binary", file=sys.stderr)
             sys.exit(1)
     else:
-        if os.path.exists('/usr/libexec/storaged/storaged'):
-            daemon_bin = 'storaged'
-        elif os.path.exists('/usr/libexec/udisks2/udisksd'):
+        if os.path.exists('/usr/libexec/udisks2/udisksd'):
             daemon_bin = 'udisksd'
 
     return daemon_bin
@@ -48,9 +44,9 @@ def setup_vdevs():
     for d in vdevs:
         with open('/sys/block/%s/device/model' %
                     os.path.basename(d)) as model_file:
-            assert model_file.read().strip() == 'storaged_test_d'
+            assert model_file.read().strip() == 'udisks_test_dis'
 
-    storagedtestcase.test_devs = vdevs
+    udiskstestcase.test_devs = vdevs
 
 def install_new_policy(projdir, tmpdir):
     '''Copies the polkit policies to the system directory and backs up eventually the existing files.
@@ -88,7 +84,7 @@ if __name__ == '__main__':
     suite = unittest.TestSuite()
     daemon_log = sys.stdout
 
-    argparser = argparse.ArgumentParser(description='storaged D-Bus test suite')
+    argparser = argparse.ArgumentParser(description='udisks D-Bus test suite')
     argparser.add_argument('-l', '--log-file', dest='logfile',
                            help='write daemon log to a file')
     argparser.add_argument('testname', nargs='*',
@@ -108,10 +104,9 @@ if __name__ == '__main__':
 
     # find which binary we're about to test: this also affects the D-Bus interface and object paths
     daemon_bin = find_daemon(projdir, args.system)
-    storagedtestcase.daemon_bin = daemon_bin
 
     if not args.system:
-        tmpdir = tempfile.TemporaryDirectory(prefix='storaged-tst-')
+        tmpdir = tempfile.TemporaryDirectory(prefix='udisks-tst-')
         policy_files = install_new_policy(projdir, tmpdir)
         conf_files = install_new_dbus_conf(projdir, tmpdir)
 
@@ -150,7 +145,7 @@ if __name__ == '__main__':
 
     # remove the fake SCSI devices and their backing files
     subprocess.call(['targetcli', 'clearconfig confirm=True'])
-    for disk_file in glob.glob("/var/tmp/storaged_test_disk*"):
+    for disk_file in glob.glob("/var/tmp/udisks_test_disk*"):
         os.unlink(disk_file)
 
     if result.wasSuccessful():

--- a/src/tests/dbus-tests/targetcli_config.json
+++ b/src/tests/dbus-tests/targetcli_config.json
@@ -30,8 +30,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk4",
-      "name": "storaged_test_disk4",
+      "dev": "/var/tmp/udisks_test_disk4",
+      "name": "udisks_test_disk4",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -66,8 +66,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk3",
-      "name": "storaged_test_disk3",
+      "dev": "/var/tmp/udisks_test_disk3",
+      "name": "udisks_test_disk3",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -102,8 +102,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk2",
-      "name": "storaged_test_disk2",
+      "dev": "/var/tmp/udisks_test_disk2",
+      "name": "udisks_test_disk2",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -138,8 +138,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk1",
-      "name": "storaged_test_disk1",
+      "dev": "/var/tmp/udisks_test_disk1",
+      "name": "udisks_test_disk1",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -174,8 +174,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk_iscsi1",
-      "name": "storaged_test_iscsi1",
+      "dev": "/var/tmp/udisks_test_disk_iscsi1",
+      "name": "udisks_test_iscsi1",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -210,8 +210,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk_iscsi2",
-      "name": "storaged_test_iscsi2",
+      "dev": "/var/tmp/udisks_test_disk_iscsi2",
+      "name": "udisks_test_iscsi2",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -246,8 +246,8 @@
         "unmap_granularity_alignment": 0,
         "unmap_zeroes_data": 0
       },
-      "dev": "/var/tmp/storaged_test_disk_iscsi3",
-      "name": "storaged_test_iscsi3",
+      "dev": "/var/tmp/udisks_test_disk_iscsi3",
+      "name": "udisks_test_iscsi3",
       "plugin": "fileio",
       "size": 524288000,
       "write_back": true,
@@ -267,7 +267,7 @@
             {
               "alias": "ea4c386be4",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_disk4"
+              "storage_object": "/backstores/fileio/udisks_test_disk4"
             }
           ],
           "node_acls": [],
@@ -289,7 +289,7 @@
             {
               "alias": "7a8a8952a0",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_disk3"
+              "storage_object": "/backstores/fileio/udisks_test_disk3"
             }
           ],
           "node_acls": [],
@@ -311,7 +311,7 @@
             {
               "alias": "d0173d579b",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_disk2"
+              "storage_object": "/backstores/fileio/udisks_test_disk2"
             }
           ],
           "node_acls": [],
@@ -333,7 +333,7 @@
             {
               "alias": "d4a2f5275c",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_disk1"
+              "storage_object": "/backstores/fileio/udisks_test_disk1"
             }
           ],
           "node_acls": [],
@@ -367,7 +367,7 @@
             {
               "alias": "121c69c714",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_iscsi1"
+              "storage_object": "/backstores/fileio/udisks_test_iscsi1"
             }
           ],
           "node_acls": [],
@@ -404,7 +404,7 @@
           "tag": 1
         }
       ],
-      "wwn": "iqn.2003-01.storaged.test:iscsi-test-noauth"
+      "wwn": "iqn.2003-01.udisks.test:iscsi-test-noauth"
     },
     {
       "fabric": "iscsi",
@@ -430,7 +430,7 @@
             {
               "alias": "f466bcd8fb",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_iscsi2"
+              "storage_object": "/backstores/fileio/udisks_test_iscsi2"
             }
           ],
           "node_acls": [
@@ -445,7 +445,7 @@
                 "random_datain_seq_offsets": 0,
                 "random_r2t_offsets": 0
               },
-              "chap_password": "storaged",
+              "chap_password": "udisks",
               "chap_userid": "iqn.1994-05.com.redhat:iscsi-test",
               "mapped_luns": [
                 {
@@ -491,7 +491,7 @@
           "tag": 1
         }
       ],
-      "wwn": "iqn.2003-01.storaged.test:iscsi-test-chap"
+      "wwn": "iqn.2003-01.udisks.test:iscsi-test-chap"
     },
     {
       "fabric": "iscsi",
@@ -517,7 +517,7 @@
             {
               "alias": "f466bcd8fb",
               "index": 0,
-              "storage_object": "/backstores/fileio/storaged_test_iscsi3"
+              "storage_object": "/backstores/fileio/udisks_test_iscsi3"
             }
           ],
           "node_acls": [
@@ -532,10 +532,10 @@
                 "random_datain_seq_offsets": 0,
                 "random_r2t_offsets": 0
               },
-              "chap_password": "storaged",
+              "chap_password": "udisks",
               "chap_userid": "iqn.1994-05.com.redhat:iscsi-test",
-              "chap_mutual_password": "storaged-mutual",
-              "chap_mutual_userid": "iqn.2003-01.storaged.test:iscsi-test-mutual",
+              "chap_mutual_password": "udisks-mutual",
+              "chap_mutual_userid": "iqn.2003-01.udisks.test:iscsi-test-mutual",
               "mapped_luns": [
                 {
                   "alias": "2387cf5a50",
@@ -580,7 +580,7 @@
           "tag": 1
         }
       ],
-      "wwn": "iqn.2003-01.storaged.test:iscsi-test-mutual"
+      "wwn": "iqn.2003-01.udisks.test:iscsi-test-mutual"
     }
   ]
 }

--- a/src/tests/dbus-tests/test_10_basic.py
+++ b/src/tests/dbus-tests/test_10_basic.py
@@ -1,11 +1,11 @@
-import storagedtestcase
+import udiskstestcase
 import dbus
 import os
 
-class StoragedBaseTest(storagedtestcase.StoragedTestCase):
+class UdisksBaseTest(udiskstestcase.UdisksTestCase):
     '''This is a base test suite'''
 
-    storaged_modules = set(['Bcache', 'BTRFS', 'ISCSI.Initiator', 'LVM2', 'ZRAM'])
+    udisks_modules = set(['Bcache', 'BTRFS', 'ISCSI.Initiator', 'LVM2', 'ZRAM'])
 
     def setUp(self):
         self.manager_obj = self.get_object('/Manager')
@@ -16,9 +16,9 @@ class StoragedBaseTest(storagedtestcase.StoragedTestCase):
         distro = release['ID'].replace('"', '')
 
         if distro in ('redhat', 'centos'):
-            return self.storaged_modules - {'Bcache'}
+            return self.udisks_modules - {'Bcache'}
         else:
-            return self.storaged_modules
+            return self.udisks_modules
 
     def test_10_manager(self):
         '''Testing the manager object presence'''

--- a/src/tests/dbus-tests/test_20_LVM.py
+++ b/src/tests/dbus-tests/test_20_LVM.py
@@ -3,17 +3,17 @@ import os
 import time
 import unittest
 
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedLVMTest(storagedtestcase.StoragedTestCase):
+class UdisksLVMTest(udiskstestcase.UdisksTestCase):
     '''This is a basic LVM test suite'''
 
     @classmethod
     def setUpClass(cls):
-        storagedtestcase.StoragedTestCase.setUpClass()
+        udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('LVM2'):
-            raise unittest.SkipTest('Storaged module for LVM tests not loaded, skipping.')
+            raise unittest.SkipTest('Udisks module for LVM tests not loaded, skipping.')
 
     def _create_vg(self, vgname, devices):
         self.udev_settle()  # Since the devices might not be ready yet
@@ -38,7 +38,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_10_linear(self):
         '''Test linear (plain) LV functionality'''
 
-        vgname = 'storaged_test_vg'
+        vgname = 'udisks_test_vg'
 
         # Use all the virtual devices but the last one
         devs = dbus.Array()
@@ -53,7 +53,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         vgsize = self.get_property(vg, '.VolumeGroup', 'Size')
         vg_freesize = self.get_property(vg, '.VolumeGroup', 'FreeSize')
         vg_freesize.assertEqual(vgsize.value)
-        lvname = 'storaged_test_lv'
+        lvname = 'udisks_test_lv'
         lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize.value), self.no_options,
                                        dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
@@ -94,7 +94,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         new_lvsize.assertEqual(new_vgsize.value)
 
         # rename the LV
-        lvname = 'storaged_test_lv2'
+        lvname = 'udisks_test_lv2'
         new_lvpath = lv.Rename(lvname, self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
         self.udev_settle()
         time.sleep(1)
@@ -120,7 +120,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_20_thin(self):
         '''Test thin volumes functionality'''
 
-        vgname = 'storaged_test_thin_vg'
+        vgname = 'udisks_test_thin_vg'
 
         # Use all the virtual devices
         devs = dbus.Array()
@@ -133,7 +133,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
 
         # Create thin pool on the VG
         vgsize = int(self.get_property_raw(vg, '.VolumeGroup', 'FreeSize'))
-        tpname = 'storaged_test_tp'
+        tpname = 'udisks_test_tp'
         tp_path = vg.CreateThinPoolVolume(tpname, dbus.UInt64(vgsize), self.no_options,
                                           dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
@@ -146,7 +146,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         tpsize = int(self.get_property_raw(tp, '.LogicalVolume', 'Size'))
 
         # Create thin volume in the pool with virtual size twice the backing pool
-        tvname = 'storaged_test_tv'
+        tvname = 'udisks_test_tv'
         tv_path = vg.CreateThinVolume(tvname, dbus.UInt64(tpsize * 2), tp, self.no_options,
                                       dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
@@ -167,7 +167,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_30_snapshot(self):
         '''Test LVM snapshoting'''
 
-        vgname = 'storaged_test_snap_vg'
+        vgname = 'udisks_test_snap_vg'
 
         # Use all the virtual devices
         devs = dbus.Array()
@@ -180,7 +180,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
 
         # Create the origin LV
         vgsize = int(self.get_property_raw(vg, '.VolumeGroup', 'FreeSize'))
-        lvname = 'storaged_test_origin_lv'
+        lvname = 'udisks_test_origin_lv'
         lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(vgsize / 2), self.no_options,
                                        dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
@@ -193,7 +193,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         time.sleep(1)
 
         # Create the LV's snapshot
-        snapname = 'storaged_test_snap_lv'
+        snapname = 'udisks_test_snap_lv'
         vg_freesize = int(self.get_property_raw(vg, '.VolumeGroup', 'FreeSize'))
         snap_path = lv.CreateSnapshot(snapname, vg_freesize, self.no_options,
                                       dbus_interface=self.iface_prefix + '.LogicalVolume')
@@ -204,7 +204,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_40_cache(self):
         '''Basic LVM cache test'''
 
-        vgname = 'storaged_test_cache_vg'
+        vgname = 'udisks_test_cache_vg'
 
         # Use all the virtual devices
         devs = dbus.Array()
@@ -217,7 +217,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
 
         # Create the origin LV
         vgsize = int(self.get_property_raw(vg, '.VolumeGroup', 'FreeSize'))
-        orig_lvname = 'storaged_test_origin_lv'
+        orig_lvname = 'udisks_test_origin_lv'
         lv_path = vg.CreatePlainVolume(orig_lvname, dbus.UInt64(vgsize / 2), self.no_options,
                                        dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
@@ -229,7 +229,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         time.sleep(1)
 
         # Create the caching LV
-        cache_lvname = 'storaged_test_cache_lv'
+        cache_lvname = 'udisks_test_cache_lv'
         vgsize = int(self.get_property_raw(vg, '.VolumeGroup', 'FreeSize'))
         lv_cache_path = vg.CreatePlainVolume(cache_lvname, dbus.UInt64(vgsize / 2), self.no_options,
                                              dbus_interface=self.iface_prefix + '.VolumeGroup')
@@ -238,7 +238,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         self.assertIsNotNone(cache_lv)
 
         # Add the cache to the origin
-        lv.CacheAttach('storaged_test_cache_lv', self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
+        lv.CacheAttach('udisks_test_cache_lv', self.no_options, dbus_interface=self.iface_prefix + '.LogicalVolume')
         self.udev_settle()
         time.sleep(1)
 
@@ -259,7 +259,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_50_rename_vg(self):
         ''' Test VG renaming '''
 
-        vgname = 'storaged_test_rename_vg'
+        vgname = 'udisks_test_rename_vg'
 
         # Use all the virtual devices
         devs = dbus.Array()
@@ -270,7 +270,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
 
         vg = self._create_vg(vgname, devs)
 
-        vgname = 'storaged_test_rename_vg2'
+        vgname = 'udisks_test_rename_vg2'
         new_vgpath = vg.Rename(vgname, self.no_options, dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()
         time.sleep(1)
@@ -289,7 +289,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
     def test_60_pvs(self):
         ''' Test adding and removing PVs from VG '''
 
-        vgname = 'storaged_test_pv_vg'
+        vgname = 'udisks_test_pv_vg'
 
         # crete vg with one pv
         old_pv = self.get_object('/block_devices/' + os.path.basename(self.vdevs[0]))
@@ -299,7 +299,7 @@ class StoragedLVMTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self._remove_vg, vg)
 
         # create an lv on it
-        lvname = 'storaged_test_lv'
+        lvname = 'udisks_test_lv'
         lv_path = vg.CreatePlainVolume(lvname, dbus.UInt64(4 * 1024**2), self.no_options,
                                        dbus_interface=self.iface_prefix + '.VolumeGroup')
         self.udev_settle()

--- a/src/tests/dbus-tests/test_30_iscsi.py
+++ b/src/tests/dbus-tests/test_30_iscsi.py
@@ -1,4 +1,4 @@
-import storagedtestcase
+import udiskstestcase
 
 import dbus
 import glob
@@ -8,25 +8,25 @@ import time
 import unittest
 
 
-class StoragedISCSITest(storagedtestcase.StoragedTestCase):
+class UdisksISCSITest(udiskstestcase.UdisksTestCase):
     '''Basic iSCSI test suite'''
 
     initiator = 'iqn.1994-05.com.redhat:iscsi-test'
-    password = 'storaged'
-    mutual_password = 'storaged-mutual'
+    password = 'udisks'
+    mutual_password = 'udisks-mutual'
 
     address = '127.0.0.1'
     port = 3260
 
-    noauth_iqn = 'iqn.2003-01.storaged.test:iscsi-test-noauth'
-    chap_iqn = 'iqn.2003-01.storaged.test:iscsi-test-chap'
-    mutual_iqn = 'iqn.2003-01.storaged.test:iscsi-test-mutual'
+    noauth_iqn = 'iqn.2003-01.udisks.test:iscsi-test-noauth'
+    chap_iqn = 'iqn.2003-01.udisks.test:iscsi-test-chap'
+    mutual_iqn = 'iqn.2003-01.udisks.test:iscsi-test-mutual'
 
     @classmethod
     def setUpClass(cls):
-        storagedtestcase.StoragedTestCase.setUpClass()
+        udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('ISCSI.Initiator'):
-            raise unittest.SkipTest('Storaged module for iscsi tests not loaded, skipping.')
+            raise unittest.SkipTest('Udisks module for iscsi tests not loaded, skipping.')
 
     def _force_lougout(self, target):
         self.run_command('iscsiadm --mode node --targetname %s --portal %s:%d '

--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -3,10 +3,10 @@ import dbus
 import glob
 import os
 import unittest
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedDriveTest(storagedtestcase.StoragedTestCase):
+class UdisksDriveTest(udiskstestcase.UdisksTestCase):
     """This is Drive related functions unit test"""
 
     def get_drive(self, device):

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -4,10 +4,10 @@ import fcntl
 import os
 import time
 
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedBlockTest(storagedtestcase.StoragedTestCase):
+class UdisksBlockTest(udiskstestcase.UdisksTestCase):
     '''This is a basic block device test suite'''
 
     def _clean_format(self, disk):

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -2,13 +2,13 @@ import dbus
 import os
 import time
 
-import storagedtestcase
+import udiskstestcase
 
 
 BLOCK_SIZE = 512
 
 
-class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
+class UdisksPartitionTableTest(udiskstestcase.UdisksTestCase):
     '''This is a basic block device test suite'''
 
     def _remove_format(self, device):
@@ -54,7 +54,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # udisks adds 1 MiB to partition start
 
         dbus_type = self.get_property(part, '.Partition', 'Type')
         dbus_type.assertEqual(part_type)
@@ -158,7 +158,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # udisks adds 1 MiB to partition start
 
         dbus_name = self.get_property(part, '.Partition', 'Name')
         dbus_name.assertEqual(gpt_name)
@@ -209,7 +209,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         size.assertEqual(100 * 1024**2)
 
         offset = self.get_property(part, '.Partition', 'Offset')
-        offset.assertEqual(2 * 1024**2)  # storaged adds 1 MiB to partition start
+        offset.assertEqual(2 * 1024**2)  # udisks adds 1 MiB to partition start
 
         usage = self.get_property(part, '.Block', 'IdUsage')
         usage.assertEqual('filesystem')
@@ -233,7 +233,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         self.assertEqual(sys_fstype, 'xfs')
 
 
-class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
+class UdisksPartitionTest(udiskstestcase.UdisksTestCase):
     '''This is a basic partition test suite'''
 
     def _remove_format(self, device):

--- a/src/tests/dbus-tests/test_70_encrypted.py
+++ b/src/tests/dbus-tests/test_70_encrypted.py
@@ -1,10 +1,10 @@
 import dbus
 import os
 
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedEncryptedTest(storagedtestcase.StoragedTestCase):
+class UdisksEncryptedTest(udiskstestcase.UdisksTestCase):
     '''This is an encrypted device test suite'''
 
     def _create_luks(self, device, passphrase):

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -2,10 +2,10 @@ import dbus
 import os
 import tempfile
 
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
+class UdisksFSTestCase(udiskstestcase.UdisksTestCase):
     _fs_name = None
     _can_create = False
     _can_label = False
@@ -80,7 +80,7 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         self.assertEqual(sys_label, label)
 
         # change the label
-        label = 'AAAA' if self._fs_name == 'vfat' else 'aaaa'  # XXX storaged changes vfat labels to uppercase
+        label = 'AAAA' if self._fs_name == 'vfat' else 'aaaa'  # XXX udisks changes vfat labels to uppercase
         disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
         # test dbus properties
@@ -186,10 +186,10 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         self.assertIn('ro', out)
 
 
-class Ext2TestCase(StoragedFSTestCase):
+class Ext2TestCase(UdisksFSTestCase):
     _fs_name = 'ext2'
-    _can_create = True and StoragedFSTestCase.command_exists('mke2fs')
-    _can_label = True and StoragedFSTestCase.command_exists('tune2fs')
+    _can_create = True and UdisksFSTestCase.command_exists('mke2fs')
+    _can_label = True and UdisksFSTestCase.command_exists('tune2fs')
     _can_mount = True
 
     def _invalid_label(self, disk):
@@ -219,10 +219,10 @@ class Ext4TestCase(Ext2TestCase):
         pass
 
 
-class XFSTestCase(StoragedFSTestCase):
+class XFSTestCase(UdisksFSTestCase):
     _fs_name = 'xfs'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.xfs')
-    _can_label = True and StoragedFSTestCase.command_exists('xfs_admin')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.xfs')
+    _can_label = True and UdisksFSTestCase.command_exists('xfs_admin')
     _can_mount = True
 
     def _invalid_label(self, disk):
@@ -232,10 +232,10 @@ class XFSTestCase(StoragedFSTestCase):
             disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
 
-class VFATTestCase(StoragedFSTestCase):
+class VFATTestCase(UdisksFSTestCase):
     _fs_name = 'vfat'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.vfat')
-    _can_label = True and StoragedFSTestCase.command_exists('fatlabel')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.vfat')
+    _can_label = True and UdisksFSTestCase.command_exists('fatlabel')
     _can_mount = True
 
     def _invalid_label(self, disk):
@@ -245,49 +245,49 @@ class VFATTestCase(StoragedFSTestCase):
             disk.SetLabel(label, self.no_options, dbus_interface=self.iface_prefix + '.Filesystem')
 
 
-class NTFSTestCase(StoragedFSTestCase):
+class NTFSTestCase(UdisksFSTestCase):
     _fs_name = 'ntfs'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.ntfs')
-    _can_label = True and StoragedFSTestCase.command_exists('ntfslabel')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.ntfs')
+    _can_label = True and UdisksFSTestCase.command_exists('ntfslabel')
     _can_mount = True
 
 
-class BTRFSTestCase(StoragedFSTestCase):
+class BTRFSTestCase(UdisksFSTestCase):
     _fs_name = 'btrfs'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.btrfs')
-    _can_label = True and StoragedFSTestCase.command_exists('btrfs')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.btrfs')
+    _can_label = True and UdisksFSTestCase.command_exists('btrfs')
     _can_mount = True
 
 
-class ReiserFSTestCase(StoragedFSTestCase):
+class ReiserFSTestCase(UdisksFSTestCase):
     _fs_name = 'reiserfs'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.reiserfs')
-    _can_label = True and StoragedFSTestCase.command_exists('reiserfstune')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.reiserfs')
+    _can_label = True and UdisksFSTestCase.command_exists('reiserfstune')
     _can_mount = True
 
 
-class MinixTestCase(StoragedFSTestCase):
+class MinixTestCase(UdisksFSTestCase):
     _fs_name = 'minix'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.minix')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.minix')
     _can_label = False
-    _can_mount = True and StoragedFSTestCase.module_loaded('minix')
+    _can_mount = True and UdisksFSTestCase.module_loaded('minix')
 
 
-class NILFS2TestCase(StoragedFSTestCase):
+class NILFS2TestCase(UdisksFSTestCase):
     _fs_name = 'nilfs2'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.nilfs2')
-    _can_label = True and StoragedFSTestCase.command_exists('nilfs-tune')
-    _can_mount = True and StoragedFSTestCase.module_loaded('nilfs2')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.nilfs2')
+    _can_label = True and UdisksFSTestCase.command_exists('nilfs-tune')
+    _can_mount = True and UdisksFSTestCase.module_loaded('nilfs2')
 
 
-class F2FSTestCase(StoragedFSTestCase):
+class F2FSTestCase(UdisksFSTestCase):
     _fs_name = 'f2fs'
-    _can_create = True and StoragedFSTestCase.command_exists('mkfs.f2fs')
+    _can_create = True and UdisksFSTestCase.command_exists('mkfs.f2fs')
     _can_label = False
-    _can_mount = True and StoragedFSTestCase.module_loaded('f2fs')
+    _can_mount = True and UdisksFSTestCase.module_loaded('f2fs')
 
 
-class FailsystemTestCase(StoragedFSTestCase):
+class FailsystemTestCase(UdisksFSTestCase):
     # test that not supported operations fail 'nicely'
 
     def test_create_format(self):
@@ -377,4 +377,4 @@ class FailsystemTestCase(StoragedFSTestCase):
         pass
 
 
-del StoragedFSTestCase  # skip StoragedFSTestCase
+del UdisksFSTestCase  # skip UdisksFSTestCase

--- a/src/tests/dbus-tests/test_90_swapspace.py
+++ b/src/tests/dbus-tests/test_90_swapspace.py
@@ -2,10 +2,10 @@
 
 import os
 import dbus
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedSwapSpaceTest(storagedtestcase.StoragedTestCase):
+class UdisksSwapSpaceTest(udiskstestcase.UdisksTestCase):
     """This is SwapSpace related functions unit test"""
 
     def get_device(self, dev_name):

--- a/src/tests/dbus-tests/test_91_lsm.py
+++ b/src/tests/dbus-tests/test_91_lsm.py
@@ -1,9 +1,9 @@
 import os
 import dbus
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedLsmLocalTestCase(storagedtestcase.StoragedTestCase):
+class UdisksLsmLocalTestCase(udiskstestcase.UdisksTestCase):
     """
     Test suit for org.freedesktop.UDisks2.Drive.LsmLocal interface.
     """
@@ -26,7 +26,7 @@ class StoragedLsmLocalTestCase(storagedtestcase.StoragedTestCase):
         self.assertIsNotNone(dbus_blk_obj)
         dbus_drv_obj = self._get_dbus_drv_obj(dbus_blk_obj)
         self.assertIsNotNone(dbus_drv_obj)
-        for method_name in StoragedLsmLocalTestCase._LED_CONTROL_METHOD_NAMES:
+        for method_name in UdisksLsmLocalTestCase._LED_CONTROL_METHOD_NAMES:
             method = dbus_drv_obj.get_dbus_method(
                 method_name,
                 dbus_interface=self.iface_prefix + ".Drive.LsmLocal")

--- a/src/tests/dbus-tests/test_bcache.py
+++ b/src/tests/dbus-tests/test_bcache.py
@@ -3,20 +3,20 @@ import re
 import time
 import unittest
 
-import storagedtestcase
+import udiskstestcase
 
 
 BLOCK_SIZE = 512
 
 
-class StoragedBcacheTest(storagedtestcase.StoragedTestCase):
+class UdisksBcacheTest(udiskstestcase.UdisksTestCase):
     '''This is a basic bcache test suite'''
 
     @classmethod
     def setUpClass(cls):
-        storagedtestcase.StoragedTestCase.setUpClass()
+        udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('Bcache'):
-            raise unittest.SkipTest('Storaged module for bcache tests not loaded, skipping.')
+            raise unittest.SkipTest('Udisks module for bcache tests not loaded, skipping.')
 
     def setUp(self):
         if os.uname().machine == "i686":

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -7,20 +7,20 @@ from bytesize import bytesize
 from collections import namedtuple
 from contextlib import contextmanager
 
-import storagedtestcase
+import udiskstestcase
 
 
 Device = namedtuple('Device', ['obj', 'path', 'name', 'size'])
 
 
-class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
+class UdisksBtrfsTest(udiskstestcase.UdisksTestCase):
     '''This is a basic test suite for btrfs interface'''
 
     @classmethod
     def setUpClass(cls):
-        storagedtestcase.StoragedTestCase.setUpClass()
+        udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('BTRFS'):
-            raise unittest.SkipTest('Storaged module for btrfs tests not loaded, skipping.')
+            raise unittest.SkipTest('Udisks module for btrfs tests not loaded, skipping.')
 
     @contextmanager
     def _temp_mount(self, device):
@@ -239,7 +239,7 @@ class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
             fstype.assertFalse()
 
         # check number of devices
-        # XXX: storaged currently often reports wrong number of devices (2)
+        # XXX: udisks currently reports wrong number of devices (2)
         # 'handle_remove_device' sets the property to '1' but after unmounting
         # the device 'on_mount_monitor_mount_removed' triggers another properties
         # update and this sets the property to '2' for some unknown reason

--- a/src/tests/dbus-tests/test_drive_ata.py
+++ b/src/tests/dbus-tests/test_drive_ata.py
@@ -4,7 +4,7 @@ import re
 import unittest
 import time
 
-from storagedtestcase import StoragedTestCase
+from udiskstestcase import UdisksTestCase
 
 # disks with (don't) support S.M.A.R.T.
 smart_unsupported = set()
@@ -12,13 +12,13 @@ smart_supported = set()
 
 sata_disks = (dev for dev in os.listdir("/dev") if re.match(r'sd[a-z]+$', dev))
 for disk in sata_disks:
-    ret, out = StoragedTestCase.run_command("smartctl -a /dev/%s" % disk)
+    ret, out = UdisksTestCase.run_command("smartctl -a /dev/%s" % disk)
     if ret == 0 and "device has SMART capability" in out:
         smart_supported.add(disk)
     else:
         smart_unsupported.add(disk)
 
-class StoragedDriveAtaTest(StoragedTestCase):
+class UdisksDriveAtaTest(UdisksTestCase):
     '''Noninvasive tests for the Drive.Ata interface'''
 
     def get_smart_setting(self, disk, attr, out_prefix):

--- a/src/tests/dbus-tests/test_job.py
+++ b/src/tests/dbus-tests/test_job.py
@@ -8,10 +8,10 @@ gi.require_version('GLib', '2.0')
 from gi.repository import GLib
 
 import safe_dbus
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedJobTest(storagedtestcase.StoragedTestCase):
+class UdisksJobTest(udiskstestcase.UdisksTestCase):
     '''This is a basic test suite for job objects and interface'''
 
     def setUp(self):

--- a/src/tests/dbus-tests/test_loop.py
+++ b/src/tests/dbus-tests/test_loop.py
@@ -2,10 +2,10 @@ import time
 import dbus
 import os
 import tempfile
-import storagedtestcase
+import udiskstestcase
 
 
-class StoragedLoopDeviceTest(storagedtestcase.StoragedTestCase):
+class UdisksLoopDeviceTest(udiskstestcase.UdisksTestCase):
     """Unit tests for the Loop interface of loop devices"""
 
     LOOP_DEVICE_FILENAME = 'loop_device.img'
@@ -40,8 +40,8 @@ class StoragedLoopDeviceTest(storagedtestcase.StoragedTestCase):
         if self.dev_name in result:
             self.fail('Test loop device was not deleted' % self.dev_name)
         # TODO: Device is still present on Dbus even when detached. This is
-        # probably a storaged and udisks2 issue. Not addressed for now to keep
-        # the same storaged/udisks2 functionality (japokorn, Nov 2016)
+        # probably a udisks and udisks2 issue. Not addressed for now to keep
+        # the same udisks/udisks2 functionality (japokorn, Nov 2016)
 
     def test_20_setautoclear(self):
         # autoclear detaches loop device as soon as it is umounted
@@ -70,7 +70,7 @@ class StoragedLoopDeviceTest(storagedtestcase.StoragedTestCase):
         uid = self.get_property(self.device, '.Loop', 'SetupByUID')
         uid.assertEqual(0)  # uid should be 0 since device is not created by Udisks
 
-class StoragedManagerLoopDeviceTest(storagedtestcase.StoragedTestCase):
+class UdisksManagerLoopDeviceTest(udiskstestcase.UdisksTestCase):
     """Unit tests for the loop-related methods of the Manager object"""
 
     LOOP_DEVICE_FILENAME = 'loop_device.img'

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -6,7 +6,7 @@ import unittest
 from collections import namedtuple
 from contextlib import contextmanager
 
-import storagedtestcase
+import udiskstestcase
 
 
 Member = namedtuple('Member', ['obj', 'path', 'name', 'size'])
@@ -26,7 +26,7 @@ def wait_for_action(action_name):
                 time.sleep(1)
 
 
-class RAIDLevel(storagedtestcase.StoragedTestCase):
+class RAIDLevel(udiskstestcase.UdisksTestCase):
     level = None
     min_members = 0
     members = None
@@ -101,7 +101,7 @@ class RAIDLevel(storagedtestcase.StoragedTestCase):
             self.skipTest('Abstract class for RAID tests.')
 
         # create the array
-        array_name = 'storaged_test_' + self.level
+        array_name = 'udisks_test_' + self.level
         array = self._array_create(array_name)
 
         # check if /dev/md/'name' exists
@@ -164,7 +164,7 @@ class RAIDLevel(storagedtestcase.StoragedTestCase):
             self.assertIn('MD_DEVICE_%s_ROLE' % member.name, md_data.keys())
             self.assertEqual(md_data['MD_DEVICE_%s_DEV' % member.name], member.path)
 
-        # test if storaged see all (active) members
+        # test if udisks see all (active) members
         dbus_devices = self.get_property(array, '.MDRaid', 'ActiveDevices')
         for dbus_dev in dbus_devices.value:
             # get matching member from self.members -- match using name and last part of dbus path
@@ -191,7 +191,7 @@ class RAID0TestCase(RAIDLevel):
         return len(self.members) * self.smallest_member.size
 
     def test_start_stop(self):
-        name = 'storaged_test_start_stop'
+        name = 'udisks_test_start_stop'
         array = self._array_create(name)
 
         dbus_running = self.get_property(array, '.MDRaid', 'Running')
@@ -216,7 +216,7 @@ class RAID0TestCase(RAIDLevel):
         self.assertEqual(ret, 0)
 
     def test_delete(self):
-        name = 'storaged_test_delete'
+        name = 'udisks_test_delete'
         array = self._array_create(name)
 
         # delete
@@ -248,7 +248,7 @@ class RAID1TestCase(RAIDLevel):
         return self.smallest_member.size
 
     def test_add_remove_device(self):
-        name = 'storaged_delete'
+        name = 'udisks_delete'
         array = self._array_create(name)
         array_path = str(array.object_path)
 
@@ -311,7 +311,7 @@ class RAID1TestCase(RAIDLevel):
         self.assertEqual(out, '')
 
     def test_bitmap_location(self):
-        array_name = 'storaged_test_bitmap'
+        array_name = 'udisks_test_bitmap'
         array = self._array_create(array_name)
 
         # get md_name ('/dev/md12X')
@@ -337,7 +337,7 @@ class RAID1TestCase(RAIDLevel):
 
     def test_request_action(self):
 
-        array_name = 'storaged_test_request'
+        array_name = 'udisks_test_request'
         array = self._array_create(array_name)
 
         # get md_name ('/dev/md12X')

--- a/src/tests/dbus-tests/test_zram.py
+++ b/src/tests/dbus-tests/test_zram.py
@@ -3,7 +3,7 @@ import re
 import time
 import unittest
 
-import storagedtestcase
+import udiskstestcase
 
 
 MODPROBECONF = '/usr/lib/modprobe.d/zram.conf'
@@ -11,7 +11,7 @@ MODLOADCONF = '/usr/lib/modules-load.d/zram.conf'
 ZRAMCONFDIR = '/usr/local/lib/zram.conf.d'
 
 
-class StoragedZRAMTest(storagedtestcase.StoragedTestCase):
+class UdisksZRAMTest(udiskstestcase.UdisksTestCase):
     '''This is a basic ZRAM test suite'''
 
     conf = {MODPROBECONF: None,
@@ -49,15 +49,15 @@ class StoragedZRAMTest(storagedtestcase.StoragedTestCase):
 
     @classmethod
     def setUpClass(cls):
-        storagedtestcase.StoragedTestCase.setUpClass()
+        udiskstestcase.UdisksTestCase.setUpClass()
         if not cls.check_module_loaded('ZRAM'):
-            raise unittest.SkipTest('Storaged module for zram tests not loaded, skipping.')
+            raise unittest.SkipTest('Udisks module for zram tests not loaded, skipping.')
 
         cls._save_conf_files()
 
     @classmethod
     def tearDownClass(cls):
-        storagedtestcase.StoragedTestCase.tearDownClass()
+        udiskstestcase.UdisksTestCase.tearDownClass()
 
         cls._restore_conf_files()
 

--- a/src/tests/dbus-tests/udiskstestcase.py
+++ b/src/tests/dbus-tests/udiskstestcase.py
@@ -4,7 +4,6 @@ import subprocess
 import os
 import time
 
-daemon_bin = None
 test_devs = None
 
 def get_call_long(call):
@@ -126,7 +125,7 @@ class DBusProperty(object):
                                                                                    len(self._value)))
 
 
-class StoragedTestCase(unittest.TestCase):
+class UdisksTestCase(unittest.TestCase):
     iface_prefix = None
     path_prefix = None
     bus = None
@@ -136,12 +135,8 @@ class StoragedTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        if daemon_bin == 'udisksd':
-            self.iface_prefix = 'org.freedesktop.UDisks2'
-            self.path_prefix = '/org/freedesktop/UDisks2'
-        elif daemon_bin == 'storaged':
-            self.iface_prefix = 'org.storaged.Storaged'
-            self.path_prefix = '/org/storaged/Storaged'
+        self.iface_prefix = 'org.freedesktop.UDisks2'
+        self.path_prefix = '/org/freedesktop/UDisks2'
         self.bus = dbus.SystemBus()
         self._orig_call_async = self.bus.call_async
         self._orig_call_blocking = self.bus.call_blocking
@@ -174,12 +169,12 @@ class StoragedTestCase(unittest.TestCase):
     @classmethod
     def get_interface(self, obj, iface_suffix):
         """Get interface for the given object either specified by an object path suffix
-        (appended to the common UDisks2/storaged prefix) or given as the object
+        (appended to the common UDisks2 prefix) or given as the object
         itself.
 
         :param obj: object to get the interface for
         :type obj: str or dbus.proxies.ProxyObject
-        :param iface_suffix: suffix appended to the common UDisks2/storaged interface prefix
+        :param iface_suffix: suffix appended to the common UDisks2 interface prefix
         :type iface_suffix: str
 
         """

--- a/src/tests/install-udisks/runtest.sh
+++ b/src/tests/install-udisks/runtest.sh
@@ -28,23 +28,23 @@
 . /usr/bin/rhts-environment.sh || exit 1
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-GIT_REPO="https://github.com/storaged-project/storaged.git"
-REPO_DIR="storaged"
+GIT_REPO="https://github.com/storaged-project/udisks.git"
+REPO_DIR="udisks"
 
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm git
 
-        rlRun "cd /home/storaged"
-        rlRun "su -c 'git clone $GIT_REPO' storaged"
+        rlRun "cd /home/udisks"
+        rlRun "su -c 'git clone $GIT_REPO' udisks"
         rlRun "cd $REPO_DIR"
-        rlRun "dnf builddep -y packaging/storaged.spec"
+        rlRun "dnf builddep -y packaging/udisks2.spec"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "su -c './autogen.sh' storaged"
-        rlRun "su -c './configure --enable-modules --localstatedir=/var' storaged"
-        rlRun "su -c 'make' storaged"
+        rlRun "su -c './autogen.sh' udisks"
+        rlRun "su -c './configure --enable-modules --localstatedir=/var' udisks"
+        rlRun "su -c 'make' udisks"
 
         rlRun "make install"
         rlRun "cp data/org.freedesktop.UDisks2 /etc/dbus-1/system.d/"

--- a/src/tests/storadectl/runtest.sh
+++ b/src/tests/storadectl/runtest.sh
@@ -34,14 +34,14 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "help"
-        rlRun "storagectl help > help.txt"
+        rlRun "udisksctl help > help.txt"
         if [ ! -s help.txt ]; then
             rlFail "No help displayed!"
         fi
     rlPhaseEnd
 
     rlPhaseStartTest "info"
-        rlRun "storagectl info -b /dev/vda2 > vda2.txt"
+        rlRun "udisksctl info -b /dev/vda2 > vda2.txt"
         # SIZE
         rlRun "cat vda2.txt | grep `lsblk -b | grep vda2 | awk {'print $4'}`"
         # IdType
@@ -50,13 +50,13 @@ rlJournalStart
         rlRun "cat vda2.txt | grep `lsblk -f | grep vda2 | awk {'print $2'}`"
         # Symlinks
         rlRun "SYMLINKS=`cat vda2.txt | grep Symlinks | awk {'print $2'}"
-        rlRun "diff `cat vda2.txt` `storagectl info -b $SYMLINKS"
+        rlRun "diff `cat vda2.txt` `udisksctl info -b $SYMLINKS"
         # UUID
         rlAssertGrep `lsblk --output-all | grep vda2 | awk {'print $6'}` vda2.txt
     rlPhaseEnd
 
     rlPhaseStartTest "dump"
-        rlRun "storagectl dump > dump.txt"
+        rlRun "udisksctl dump > dump.txt"
         for dev in `ll /dev/block/ | grep -v total | awk {'print $11'} | sed 's/..\///'`
         do
             rlAssertGrep " Device: /dev/$dev" dump.txt
@@ -64,7 +64,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "status"
-        rlRun "storagectl status > status.txt"
+        rlRun "udisksctl status > status.txt"
         rlRun "lsblk > lsblk.txt"
 
         for dev in `cat status.txt`
@@ -74,18 +74,18 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "monitor"
-        rlRun "storagectl monitor &"
-        rlRun "ps -ax | grep storagectl"
+        rlRun "udisksctl monitor &"
+        rlRun "ps -ax | grep udisksctl"
     rlPhaseEnd
 
     rlPhaseStartTest "mount"
         # not finished
-        rlRun "storagectl mount -b /dev/vda3"
+        rlRun "udisksctl mount -b /dev/vda3"
     rlPhaseEnd
 
     rlPhaseStartCleanup
         rlRun "rm -rf *.txt"
-        rlRun "pkill -9 storagectl"
+        rlRun "pkill -9 udisksctl"
     rlPhaseEnd
 
 rlJournalPrintText

--- a/src/udiskslinuxpartitiontable.c
+++ b/src/udiskslinuxpartitiontable.c
@@ -806,7 +806,7 @@ handle_create_partition (UDisksPartitionTable   *table,
      temporarily, but it still happens that the block device is
      missing exactly when wipefs or mkfs try to access it.
 
-     Also, a pair of remove/add events will cause storaged to create a
+     Also, a pair of remove/add events will cause udisks to create a
      new internal UDisksObject to represent the block device of the
      partition.  The code currently doesn't handle this and waits for
      changes (such as an expected filesystem type or UUID) to a

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://fedora.zanata.org/</url>
-  <project>storaged</project>
-  <project-version>storaged</project-version>
+  <project>udisks</project>
+  <project-version>udisks</project-version>
   <project-type>gettext</project-type>
   <src-dir>po</src-dir>
   <trans-dir>po</trans-dir>


### PR DESCRIPTION
This was done with:

 1. Manually renaming `find -iname '*storage*'`. Note that we use
    udisks2.spec instead of udisks.spec to get back to the previous
    package name in Fedora/RHEL.

 2. Automatic mass-renaming with
    git ls-tree -r --name-only HEAD|grep -v NEWS | xargs sed -ri \
        's/storagedtestcase/udiskstestcase/g; s/Storaged([[:alnum:]]*)Test/Udisks\1Test/g;
         s/storaged.spec/udisks2.spec/g; s/storaged(_|\b)/udisks\1/g;
         s/Storaged/Udisks/g; s/storagectl/udisksctl/g; s/udisks-project/storaged-project/g'

    Note that we must not touch the checked STORAGED_* udev properties;
    they are already only a fallback for the UDISKS_* properties, and we
    should keep them for backwards compatibility with user-created udev
    rules for a while. We also keep "storaged-project" as GitHub owner
    as that's hard to change and not very visible in releases anyway.

   3. Remove the "is a fork.." message from README.md, and change
      top-level project name in NEWS.
 
   4. Review the remaining potential names and ensure they are unrelated:
    git grep -i storage| grep -Evi '(^NEWS|libstoragemgmt|STORAGED_|Rapid Storage|vsphere-50-storage|Apple Core Storage)'

----

As discussed last week. A `make install` works and looks plausible, `src/tests/integration-test` works, and `make check` succeeds after also applying the fix in PR #190 . The latter also fails its integration tests, and they are not visible to me; I figure this will need some corresponding changes in the test infrastructure and zatana.