### PR TITLE
DBus tests: Always use lsblk with -d (--nodeps) option

### DIFF
--- a/src/tests/dbus-tests/test_40_drive.py
+++ b/src/tests/dbus-tests/test_40_drive.py
@@ -91,7 +91,7 @@ class StoragedDriveTest(storagedtestcase.StoragedTestCase):
             return self.read_file(os.path.join(sys_dir, value)).strip()
 
         serial = read_sys_file('wwid').rsplit(None, 1)[-1]  # get the last word in the file
-        ret_code, wwn = self.run_command('lsblk -no WWN %s' % self.cd_dev)
+        ret_code, wwn = self.run_command('lsblk -d -no WWN %s' % self.cd_dev)
         self.assertEqual(ret_code, 0)
 
         # values expected are preset by scsi_debug and do not change

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -32,7 +32,7 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         fstype = self.get_property(disk, '.Block', 'IdType')
         fstype.assertEqual('xfs')
 
-        _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
+        _ret, sys_fstype = self.run_command('lsblk -d -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_fstype, 'xfs')
 
         # remove the format
@@ -45,7 +45,7 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         fstype = self.get_property(disk, '.Block', 'IdType')
         fstype.assertEqual('')
 
-        _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
+        _ret, sys_fstype = self.run_command('lsblk -d -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_fstype, '')
 
     def test_format_parttype(self):
@@ -74,7 +74,7 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         dbus_type.assertIn(['0x42', '0x82'])
 
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertIn(sys_type, ['0x42', '0x82'])
 
     def test_open(self):

--- a/src/tests/dbus-tests/test_60_partitioning.py
+++ b/src/tests/dbus-tests/test_60_partitioning.py
@@ -71,12 +71,12 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         sys_start = int(self.read_file('%s/start' % part_syspath))
         self.assertEqual(sys_start * BLOCK_SIZE, 2 * 1024**2)
 
-        _ret, sys_type = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertEqual(sys_type, part_type)
 
         # check uuid and part number
         dbus_uuid = self.get_property(part, '.Partition', 'UUID')
-        _ret, sys_uuid = self.run_command('lsblk -no PARTUUID /dev/%s' % part_name)
+        _ret, sys_uuid = self.run_command('lsblk -d -no PARTUUID /dev/%s' % part_name)
         dbus_uuid.assertEqual(sys_uuid)
 
         dbus_num = self.get_property(part, '.Partition', 'Number')
@@ -112,7 +112,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
 
         # check system type
         part_name = str(ext_part.object_path).split('/')[-1]
-        _ret, sys_pttype = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_pttype = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertIn(sys_pttype, ['0x5', '0xf', '0x85'])  # lsblk prints 0xf instead of 0x0f
 
         # create logical partition
@@ -178,10 +178,10 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         sys_start = int(self.read_file('%s/start' % part_syspath))
         self.assertEqual(sys_start * BLOCK_SIZE, 2 * 1024**2)
 
-        _ret, sys_name = self.run_command('lsblk -no PARTLABEL /dev/%s' % part_name)
+        _ret, sys_name = self.run_command('lsblk -d -no PARTLABEL /dev/%s' % part_name)
         self.assertEqual(sys_name, gpt_name)
 
-        _ret, sys_type = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertEqual(sys_type, gpt_type)
 
     def test_create_with_format(self):
@@ -229,7 +229,7 @@ class StoragedPartitionTableTest(storagedtestcase.StoragedTestCase):
         sys_start = int(self.read_file('%s/start' % part_syspath))
         self.assertEqual(sys_start * BLOCK_SIZE, 2 * 1024**2)
 
-        _ret, sys_fstype = self.run_command('lsblk -no FSTYPE /dev/%s' % part_name)
+        _ret, sys_fstype = self.run_command('lsblk -d -no FSTYPE /dev/%s' % part_name)
         self.assertEqual(sys_fstype, 'xfs')
 
 
@@ -312,7 +312,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_flags = self.run_command('lsblk -no PARTFLAGS /dev/%s' % part_name)
+        _ret, sys_flags = self.run_command('lsblk -d -no PARTFLAGS /dev/%s' % part_name)
         self.assertEqual(sys_flags, '0x80')
 
     def test_gpt_type(self):
@@ -340,7 +340,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertEqual(sys_type, home_guid)
 
     def test_dos_type(self):
@@ -368,7 +368,7 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_type = self.run_command('lsblk -no PARTTYPE /dev/%s' % part_name)
+        _ret, sys_type = self.run_command('lsblk -d -no PARTTYPE /dev/%s' % part_name)
         self.assertEqual(sys_type, part_type)
 
     def test_name(self):
@@ -396,5 +396,5 @@ class StoragedPartitionTest(storagedtestcase.StoragedTestCase):
 
         # test flags value from sysytem
         part_name = str(part.object_path).split('/')[-1]
-        _ret, sys_name = self.run_command('lsblk -no PARTLABEL /dev/%s' % part_name)
+        _ret, sys_name = self.run_command('lsblk -d -no PARTLABEL /dev/%s' % part_name)
         self.assertEqual(sys_name, 'test')

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -48,7 +48,7 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         fstype.assertEqual(self._fs_name)
 
         # test system values
-        _ret, sys_fstype = self.run_command('lsblk -no FSTYPE %s' % self.vdevs[0])
+        _ret, sys_fstype = self.run_command('lsblk -d -no FSTYPE %s' % self.vdevs[0])
         self.assertEqual(sys_fstype, self._fs_name)
 
     def _invalid_label(self, disk):
@@ -76,7 +76,7 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         dbus_label.assertEqual(label)
 
         # test system values
-        _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])
+        _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % self.vdevs[0])
         self.assertEqual(sys_label, label)
 
         # change the label
@@ -88,7 +88,7 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         dbus_label.assertEqual(label)
 
         # test system values
-        _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])
+        _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % self.vdevs[0])
         self.assertEqual(sys_label, label)
 
         # test invalid label behaviour
@@ -201,7 +201,7 @@ class Ext2TestCase(StoragedFSTestCase):
         dbus_label.assertEqual(label[0:16])
 
         # test system values
-        _ret, sys_label = self.run_command('lsblk -no LABEL %s' % self.vdevs[0])
+        _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % self.vdevs[0])
         self.assertEqual(sys_label, label[0:16])
 
 

--- a/src/tests/dbus-tests/test_btrfs.py
+++ b/src/tests/dbus-tests/test_btrfs.py
@@ -48,7 +48,7 @@ class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
             dev_obj = self.get_object('/block_devices/' + dev_name)
             self.assertIsNotNone(dev_obj)
 
-            _ret, out = self.run_command('lsblk -b -no SIZE %s' % dev_path)  # get size of the device
+            _ret, out = self.run_command('lsblk -d -b -no SIZE %s' % dev_path)  # get size of the device
 
             dev = Device(dev_obj, dev_path, dev_name, int(out))
             devices.append(dev)
@@ -74,12 +74,12 @@ class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
 
         # check '.Filesystem.BTRFS' properties
         dbus_label = self.get_property(dev.obj, '.Filesystem.BTRFS', 'label')
-        _ret, sys_label = self.run_command('lsblk -no LABEL %s' % dev.path)
+        _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % dev.path)
         dbus_label.assertEqual('test_single')
         dbus_label.assertEqual(sys_label)
 
         dbus_uuid = self.get_property(dev.obj, '.Filesystem.BTRFS', 'uuid')
-        _ret, sys_uuid = self.run_command('lsblk -no UUID %s' % dev.path)
+        _ret, sys_uuid = self.run_command('lsblk -d -no UUID %s' % dev.path)
         dbus_uuid.assertEqual(sys_uuid)
 
         dbus_devs = self.get_property(dev.obj, '.Filesystem.BTRFS', 'num_devices')
@@ -124,12 +124,12 @@ class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
 
             # check '.Filesystem.BTRFS' properties
             dbus_label = self.get_property(dev.obj, '.Filesystem.BTRFS', 'label')
-            _ret, sys_label = self.run_command('lsblk -no LABEL %s' % dev.path)
+            _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % dev.path)
             dbus_label.assertEqual('test_raid1')
             dbus_label.assertEqual(sys_label)
 
             dbus_uuid = self.get_property(dev.obj, '.Filesystem.BTRFS', 'uuid')
-            _ret, sys_uuid = self.run_command('lsblk -no UUID %s' % dev.path)
+            _ret, sys_uuid = self.run_command('lsblk -d -no UUID %s' % dev.path)
             dbus_uuid.assertEqual(sys_uuid)
 
             dbus_devs = self.get_property(dev.obj, '.Filesystem.BTRFS', 'num_devices')
@@ -316,5 +316,5 @@ class StoragedBtrfsTest(storagedtestcase.StoragedTestCase):
         dbus_label = self.get_property(dev.obj, '.Filesystem.BTRFS', 'label')
         dbus_label.assertEqual('new_label')
 
-        _ret, sys_label = self.run_command('lsblk -no LABEL %s' % dev.path)
+        _ret, sys_label = self.run_command('lsblk -d -no LABEL %s' % dev.path)
         self.assertEqual(sys_label, 'new_label')

--- a/src/tests/dbus-tests/test_job.py
+++ b/src/tests/dbus-tests/test_job.py
@@ -81,7 +81,7 @@ class StoragedJobTest(storagedtestcase.StoragedTestCase):
         # get all the properties from the dict
         properties = self.job[1][self.iface_prefix + '.Job']
 
-        _ret, disk_size = self.run_command('lsblk -b -no SIZE %s' % self.vdevs[0])  # get size of the device
+        _ret, disk_size = self.run_command('lsblk -d -b -no SIZE %s' % self.vdevs[0])  # get size of the device
         self.assertEqual(properties['Bytes'], int(disk_size))
 
         self.assertEqual(properties['StartedByUID'], os.getuid())

--- a/src/tests/dbus-tests/test_mdraid.py
+++ b/src/tests/dbus-tests/test_mdraid.py
@@ -42,7 +42,7 @@ class RAIDLevel(storagedtestcase.StoragedTestCase):
             dev_name = os.path.basename(dev)
             dev_obj = self.get_object('/block_devices/' + dev_name)
             self.assertIsNotNone(dev_obj)
-            _ret, out = self.run_command('lsblk -b -no SIZE %s' % dev)  # get size of the device
+            _ret, out = self.run_command('lsblk -d -b -no SIZE %s' % dev)  # get size of the device
             self.members.append(Member(obj=dev_obj, path=dev, name=dev_name, size=int(out)))
 
     @property
@@ -155,7 +155,7 @@ class RAIDLevel(storagedtestcase.StoragedTestCase):
         dbus_size = self.get_property(array, '.MDRaid', 'Size')
         self.assertLessEqual(self.size - dbus_size.value, 0.005 * self.size)
 
-        _ret, out = self.run_command('lsblk -b -no SIZE /dev/md/%s' % array_name)
+        _ret, out = self.run_command('lsblk -d -b -no SIZE /dev/md/%s' % array_name)
         self.assertEqual(dbus_size.value, int(out))
 
         # test if mdadm see all members
@@ -231,7 +231,7 @@ class RAID0TestCase(RAIDLevel):
 
         # check if members have been wiped and 'MDRaidMember' property is updated
         for member in self.members:
-            _ret, out = self.run_command('lsblk -no FSTYPE %s' % member.path)
+            _ret, out = self.run_command('lsblk -d -no FSTYPE %s' % member.path)
             self.assertEqual(out, '')
 
             dbus_member = self.get_property(member.obj, '.Block', 'MDRaidMember')
@@ -307,7 +307,7 @@ class RAID1TestCase(RAIDLevel):
         dbus_member.assertEqual('/')  # default value for 'non-raid' devices is '/'
 
         # with 'wipe' option, device should be wiped
-        _ret, out = self.run_command('lsblk -no FSTYPE %s' % new_path)
+        _ret, out = self.run_command('lsblk -d -no FSTYPE %s' % new_path)
         self.assertEqual(out, '')
 
     def test_bitmap_location(self):


### PR DESCRIPTION
With this option, lsblk will always print information just for
given device and for its children.