### PR TITLE
Fix and improvement for threaded jobs

### DIFF
--- a/doc/udisks2-sections.txt.in.in
+++ b/doc/udisks2-sections.txt.in.in
@@ -188,6 +188,7 @@ udisks_spawned_job_get_type
 UDisksThreadedJob
 UDisksThreadedJobFunc
 udisks_threaded_job_new
+udisks_threaded_job_start
 udisks_threaded_job_get_user_data
 <SUBSECTION Standard>
 UDISKS_TYPE_THREADED_JOB

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -468,6 +468,7 @@ test_threaded_job_successful (void)
   UDisksThreadedJob *job;
 
   job = udisks_threaded_job_new (threaded_job_successful_func, NULL, NULL, NULL, NULL);
+  udisks_threaded_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_success), NULL);
   g_object_unref (job);
 }
@@ -494,6 +495,7 @@ test_threaded_job_failure (void)
   UDisksThreadedJob *job;
 
   job = udisks_threaded_job_new (threaded_job_failure_func, NULL, NULL, NULL, NULL);
+  udisks_threaded_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Threaded job failed with error: some error (g-key-file-error-quark, 5)");
   g_object_unref (job);
@@ -510,6 +512,7 @@ test_threaded_job_cancelled_at_start (void)
   cancellable = g_cancellable_new ();
   g_cancellable_cancel (cancellable);
   job = udisks_threaded_job_new (threaded_job_successful_func, NULL, NULL, NULL, cancellable);
+  udisks_threaded_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Threaded job failed with error: Operation was cancelled (g-io-error-quark, 19)");
   g_object_unref (job);
@@ -550,6 +553,7 @@ test_threaded_job_cancelled_midway (void)
   count = 0;
   job = udisks_threaded_job_new (threaded_job_sleep_until_cancelled, &count, NULL, NULL, cancellable);
   g_timeout_add (10, on_timeout, cancellable); /* 10 msec */
+  udisks_threaded_job_start (job);
   g_main_loop_run (loop);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Threaded job failed with error: Operation was cancelled (g-io-error-quark, 19)");
@@ -584,6 +588,7 @@ test_threaded_job_override_signal_handler (void)
   job = udisks_threaded_job_new (threaded_job_failure_func, NULL, NULL, NULL, NULL);
   handler_ran = FALSE;
   g_signal_connect (job, "threaded-job-completed", G_CALLBACK (on_threaded_job_completed), &handler_ran);
+  udisks_threaded_job_start (job);
   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
                              (gpointer) "Threaded job failed with error: some error (g-key-file-error-quark, 5)");
   g_assert (handler_ran);

--- a/src/udisksdaemon.h
+++ b/src/udisksdaemon.h
@@ -139,6 +139,16 @@ UDisksBaseJob            *udisks_daemon_launch_threaded_job   (UDisksDaemon     
                                                                GDestroyNotify         user_data_free_func,
                                                                GCancellable          *cancellable);
 
+gboolean                 udisks_daemon_launch_threaded_job_sync (UDisksDaemon          *daemon,
+                                                                 UDisksObject          *object,
+                                                                 const gchar           *job_operation,
+                                                                 uid_t                  job_started_by_uid,
+                                                                 UDisksThreadedJobFunc  job_func,
+                                                                 gpointer               user_data,
+                                                                 GDestroyNotify         user_data_free_func,
+                                                                 GCancellable          *cancellable,
+                                                                 GError               **error);
+
 /* Return value and *uuid_ret must be freed with g_free.  If return
    value is NULL, *uuid has not been changed.
  */

--- a/src/udiskslinuxdriveata.c
+++ b/src/udiskslinuxdriveata.c
@@ -1232,6 +1232,7 @@ handle_smart_selftest_start (UDisksDriveAta        *_drive,
                                                                                     g_object_ref (drive),
                                                                                     g_object_unref,
                                                                                     NULL)); /* GCancellable */
+      udisks_threaded_job_start (drive->selftest_job);
     }
   G_UNLOCK (object_lock);
 

--- a/src/udiskslinuxswapspace.c
+++ b/src/udiskslinuxswapspace.c
@@ -234,6 +234,7 @@ handle_start (UDisksSwapspace        *swapspace,
                     "completed",
                     G_CALLBACK (swapspace_start_on_job_completed),
                     invocation);
+  udisks_threaded_job_start (job);
 
  out:
   g_clear_object (&object);
@@ -344,6 +345,7 @@ handle_stop (UDisksSwapspace        *swapspace,
                     "completed",
                     G_CALLBACK (swapspace_stop_on_job_completed),
                     invocation);
+  udisks_threaded_job_start (job);
 
  out:
   return TRUE;

--- a/src/udisksthreadedjob.h
+++ b/src/udisksthreadedjob.h
@@ -35,6 +35,7 @@ UDisksThreadedJob *udisks_threaded_job_new              (UDisksThreadedJobFunc  
                                                          GDestroyNotify         user_data_free_func,
                                                          UDisksDaemon          *daemon,
                                                          GCancellable          *cancellable);
+void udisks_threaded_job_start (UDisksThreadedJob *job);
 gpointer           udisks_threaded_job_get_user_data    (UDisksThreadedJob     *job);
 
 G_END_DECLS


### PR DESCRIPTION
The former commit fixes a potential race condition when running threaded jobs. The latter one adds a function for running threaded jobs synchronously. Which is needed for replacing synchronous spawned jobs running utilities with threaded jobs running *libblockdev* functions.

note: **this PR is for the master-libblockdev branch**