### PR TITLE
Fix how job->input_string_cursor is reset

### DIFF
--- a/src/udisksspawnedjob.c
+++ b/src/udisksspawnedjob.c
@@ -983,7 +983,8 @@ void udisks_spawned_job_start (UDisksSpawnedJob *job)
 
   if (job->child_stdin_fd != -1)
     {
-      job->input_string_cursor = job->input_string;
+      if (job->input_string)
+        job->input_string_cursor = job->input_string->str;
 
       job->child_stdin_channel = g_io_channel_unix_new (job->child_stdin_fd);
       // we want to write binary, suppress checking the encoding:


### PR DESCRIPTION
This is a serious issue overlooked and introduced in the PR #189
(d66e8f3600421d0e3f83d195456693999ffe40f8).