### PR TITLE
Skip bcache tests on 32bit Intel

### DIFF
--- a/src/tests/dbus-tests/test_bcache.py
+++ b/src/tests/dbus-tests/test_bcache.py
@@ -18,6 +18,11 @@ class StoragedBcacheTest(storagedtestcase.StoragedTestCase):
         if not cls.check_module_loaded('Bcache'):
             raise unittest.SkipTest('Storaged module for bcache tests not loaded, skipping.')
 
+    def setUp(self):
+        if os.uname().machine == "i686":
+            self.skipTest("Skipping bcache tests on 32bit architecture")
+        super().setUp()
+
     def _force_remove(self, bcache_name, backing_dev, cache_dev):
         _ret, out = self.run_command('bcache-super-show %s | grep cset.uuid ' % cache_dev)
         cset_uuid = out.split()[-1]


### PR DESCRIPTION
For some reason, they are failing in a very weird way. The libblockdev-bcache
tests are working just fine on the same machine/system so there must be
something wrong in the way storaged creates bcache. Definitely something worth
investigating, but right now we can just skip the tests so that we can run the
other ones properly even on i686.